### PR TITLE
Updated acropolis/install.md to use new key

### DIFF
--- a/acropolis/install.md
+++ b/acropolis/install.md
@@ -100,7 +100,7 @@ An alternative method is to use the .deb packages available on Debian or Ubuntu:
 
 ```bash
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 sudo apt-get update
 sudo apt-get install python3-vcstool python3-colcon-common-extensions
 ```


### PR DESCRIPTION
When following the instructions in `acropolis/install.md`, 
```sh
sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
```
results in 
```
Executing: /tmp/apt-key-gpghome.3aASuyLMDd/gpg.1.sh --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
gpg: key 847F3CEFB01FA116: public key "Totally Legit Signing Key <mallory@example.org>" imported
gpg: key 5523BAEEB01FA116: public key "ROS Builder <rosbuild@ros.org>" imported
gpg: Total number processed: 2
gpg:               imported: 2
```
which adds an outdated key per https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454 and what seems to be a random unrelated key. This results in the following error.
```sh
Err:15 http://packages.ros.org/ros/ubuntu bionic InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654
```

This change updates the install instructions to use the newer key as recommended in the instructions above, and `sudo apt install python3-vcstool python3-colcon-common-extensions` works as expected.