### PR TITLE
add citadel gui tutorials to index

### DIFF
--- a/citadel/index.yaml
+++ b/citadel/index.yaml
@@ -37,3 +37,15 @@ pages:
   - name: comparison
     title: Feature Comparison
     file: comparison.md
+  - name: gui
+    title: Understanding the GUI
+    file: GUI_tutorial.md
+  - name: manipulating_models
+    title: Manipulating Models
+    file: Manipulating_models.md
+  - name: fuel_insert
+    title: Model Insertion from Fuel
+    file: Model_insertion_fuel.md
+  - name: hotkeys
+    title: Keyboard Shortcuts
+    file: hotkeys.md


### PR DESCRIPTION
Forgot to add these pages to the index.yaml file so they're not available on the site yet

Signed-off-by: maryaB-osr <marya@openrobotics.org>