### PR TITLE
More link fixes

### DIFF
--- a/blueprint/Manipulating_models.md
+++ b/blueprint/Manipulating_models.md
@@ -17,7 +17,7 @@ Start by getting Ignition up and running with a sample world:
 ign gazebo shapes.sdf
 ```
 
-The previous tutorial, [Understanding the GUI](GUI_tutorial), explains the basics of navigating the Ignition GUI.
+The previous tutorial, [Understanding the GUI](/docs/blueprint/gui), explains the basics of navigating the Ignition GUI.
 
 ## Transform Control
 
@@ -130,4 +130,4 @@ You can also select multiple entities to face simultaneously from each view angl
 
 So far you've interacted with basic shape models to learn about Ignition's GUI.
 It's also possible to insert more detailed models from [Ignition Fuel](https://app.ignitionrobotics.org) into the GUI.
-Check out the [Model Insertion from Fuel](/docs/blueprint/Model_insertion_fuel) tutorial to learn how.
+Check out the [Model Insertion from Fuel](/docs/blueprint/fuel_insert) tutorial to learn how.

--- a/citadel/GUI_tutorial.md
+++ b/citadel/GUI_tutorial.md
@@ -113,4 +113,4 @@ The function of the World Control options will become clearer once you begin man
 
 ## Next Up
 
-Now that you're comfortable with Ignition GUI navigation and terminology, let's start learning about more meaningful model interactions with the [Manipulating Models](/docs/citadel/Manipulating_models) tutorial.
+Now that you're comfortable with Ignition GUI navigation and terminology, let's start learning about more meaningful model interactions with the [Manipulating Models](/docs/citadel/manipulating_models) tutorial.

--- a/citadel/Manipulating_models.md
+++ b/citadel/Manipulating_models.md
@@ -19,7 +19,7 @@ Start by getting Ignition up and running with a sample world:
 ign gazebo shapes.sdf
 ```
 
-The previous tutorial, [Understanding the GUI](/docs/citadel/GUI_tutorial), explains the basics of navigating the Ignition GUI.
+The previous tutorial, [Understanding the GUI](/docs/citadel/gui), explains the basics of navigating the Ignition GUI.
 
 ## Transform Control
 
@@ -145,4 +145,4 @@ You can align more than two models, just select the others with `Ctrl` + click.
 
 So far you've interacted with basic shape models to learn about Ignition's GUI.
 It's also possible to insert more detailed models from [Ignition Fuel](https://app.ignitionrobotics.org) into the GUI.
-Check out the [Model Insertion from Fuel](/docs/citadel/Model_insertion_fuel) tutorial to learn how.
+Check out the [Model Insertion from Fuel](/docs/citadel/fuel_insert) tutorial to learn how.


### PR DESCRIPTION
We need to be careful to use the tutorial `name`s from `index.yaml`, not the `file`.

https://github.com/ignitionrobotics/docs/blob/d4afb7a39ab4ead52c24f14f607ab0d18dc38cab/blueprint/index.yaml#L18-L38