### PR TITLE
Extend Blueprint's life by 3 months

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -15,7 +15,7 @@ An Ignition release follows the form "Ignition Codename", for example Ignition A
 | Name       | Date      | EOL date  | Notes |
 |------------|-----------|-----------|-------|
 | Acropolis  | Feb, 2019 | Sep, 2019 |       |
-| Blueprint  | May, 2019 | Sep, 2020 |       |
+| Blueprint  | May, 2019 | Dec, 2020 |       |
 | Citadel    | Dec, 2019 | Dec, 2024 | LTS   |
 | Dome       | Sep, 2020 | Sep, 2021 |       |
 | Ignition-E | Mar, 2021 | Mar, 2022 |       |


### PR DESCRIPTION
This should give users some overlap between Blueprint and Dome in case they want to migrate straight to Dome, skipping Citadel.