### PR TITLE
Quarterly roadmap links to tickets

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -26,7 +26,10 @@ plugins, SDF files, and other simulation resources from Gazebo to Ignition.
 
 * **Documentation**: Improve documentation release process and usability.
 Port relevant Gazebo tutorials to Ignition.
-    * TODO
+    * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22boost+the+docs%22&state=open&type=Issues)
+      with the "migration" label.
+    * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22boost+the+docs%22)
+      for tickets with the "migration" label.
 
 ## 2020 Q4(Oct - Dec)
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -27,9 +27,9 @@ plugins, SDF files, and other simulation resources from Gazebo to Ignition.
 * **Documentation**: Improve documentation release process and usability.
 Port relevant Gazebo tutorials to Ignition.
     * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22boost+the+docs%22&state=open&type=Issues)
-      with the "migration" label.
+      with the "boost the docs" label.
     * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22boost+the+docs%22)
-      for tickets with the "migration" label.
+      for tickets with the "boost the docs" label.
 
 ## 2020 Q4(Oct - Dec)
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -4,27 +4,45 @@ This page describes planned work for Ignition Robotics. The set of planned
 features and development efforts should provide insight into the overall
 direction of Ignition Robotics. If you would like to
 see other features on the roadmap, then please get in touch with us at
-info@openrobotics.org. 
+info@openrobotics.org.
 
 ## Quarterly Roadmap
 
 **Close the Gap** is Ignition's current focus topic. Over the next two
 quarters we will concentrate development efforts on topics that reduce
 feature disparity between Gazebo and Ignition and facilitate migration from
-Gazebo to Ignition. Take a look at the [feature comparison](/docs/citadel/comparison) page for a list of differences between Gazebo and Ignition.
+Gazebo to Ignition. Take a look at the
+[feature comparison](/docs/citadel/comparison) page for a list of
+differences between Gazebo and Ignition.
 
 ## 2020 Q3(Jul - Sep)
 
 * **Migration Strategies**: Develop and document strategies for migrating
 plugins, SDF files, and other simulation resources from Gazebo to Ignition.
+    * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22migration%22&state=open&type=Issues)
+      with the "migration" label.
+    * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22migration%22)
+      for tickets with the "migration" label.
 
 * **Documentation**: Improve documentation release process and usability.
 Port relevant Gazebo tutorials to Ignition.
+    * TODO
 
 ## 2020 Q4(Oct - Dec)
 
 * **Cross platform compatibility**: Fully support Windows, Ubuntu, and macOS.
+    * Windows
+        * [All open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3AWindows&type=Issues)
+        * [Status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3AWindows)
+    * macOS
+        * [All open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3AmacOS&type=Issues)
+        * [Status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3AmacOS)
+
 * **Feature parity**: Port features from Gazebo that are missing in Ignition.
+    * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22close+the+gap%22&state=open&type=Issues)
+      with the "close the gap" label.
+    * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22close+the+gap%22)
+      for tickets with the "close the gap" label.
 
 ## Feature Roadmap
 
@@ -61,7 +79,7 @@ and release pattern allows us to distribute patch and minor updates into an alre
 1. Efficient skeleton animations.
 1. Localized wind (wind that is constrained to a region of influence).
 1. Design for Enhanced distributed simulation.
-1. OpenGL shaders to simulate underwater effects in camera sensors. 
+1. OpenGL shaders to simulate underwater effects in camera sensors.
 1. Mesh level of detail support.
 
 ## Planned releases


### PR DESCRIPTION
Add links to tickets so the reader can have better visibility into the implementation details and current status.

We're relying on labels so that tickets are more easily discoverable and can be organized in different ways.

The **migration** and **documentation infrastructure** efforts will be more tightly scoped and have a small set of tasks from the beginning.

**Cross-platform support** may increase as we discover new challenges, and some issues may be left out of the scope for Q4, like specific tests and features.

**Feature parity** will be prioritized as we get closer to Q4 and most tickets will be left out for later.

CC @clalancette