### PR TITLE
Nightly upload of API docs and library tutorials

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,0 +1,29 @@
+name: Upload docs to production
+
+on:
+  schedule:
+    # UTC timezone
+    - cron: '0 6 * * *'
+
+jobs:
+  upload:
+    name: Upload docs to production
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup S3 cmd
+      run: |
+        sudo apt-get update &&
+        sudo apt-get install s3cmd awscli &&
+        s3cmd --configure --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --no-encrypt --dump-config > $HOME/.s3cfg &&
+        ls $HOME/.s3cfg
+    - name: Run nightly upload
+      run: cd tools && bash build_docs.sh all
+      env:
+        IGN_VERSION_PASSWORD: ${{ secrets.IGN_VERSION_PASSWORD }}
+    - name: Invalidate Cloudfront distribution
+      run: |
+        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} &&
+        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} &&
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 #
 # Usage
-#   1. Make sure you have the s3cmd tool configured. This script will use your 
+#   1. Make sure you have the s3cmd tool configured. This script will use your
 #      ~/.s3cfg file to upload documentation.
 #   2. Documentation upload requires a password to
 #      https://api.ignitionrobotics.org. The password is listed on the
 #      internal Open Robotics wiki. Set the IGN_VERSION_PASSWORD environment
 #      variable to the correct password before running this script.
-#   3. Run this command when you want to upload ALL of the Ignition library 
+#   3. Run this command when you want to upload ALL of the Ignition library
 #      documentation. This will not upload the documentation contained in this
 #      repository. To do that, you'll need to make a release of the
 #      api.ignitionrobotics.org server (see the
 #      bitbucket.org/ignitionrobotics/ign-webserver repository).
-#         
+#
 #           sh ./build_docs.sh <release_name | all>
 #
 #   4. Once complete you'll need to invalidate the Cloudfront distribution using
@@ -28,7 +28,7 @@ s3cmd --dump-config > s3.cfg
 # Build the docker container, which also uploads all documentation.
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
-if [[ $1 == 'all' || $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
+if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 


### PR DESCRIPTION
Resolves #30 

This will upload the API documentation and tutorials for Blueprint and Citadel nightly. This includes all the pages under `/api`, such as:

* API: https://ignitionrobotics.org/api/common/3.6/classes.html
* Library tutorials: https://ignitionrobotics.org/api/gazebo/3.2/tutorials.html

I tested this on my fork last night and I believe everything is working.

* Doc generation and upload to S3 worked correctly on schedule, but failed to invalidate cloudfront: https://github.com/chapulina/docs/actions/runs/205103091
* Then I tested fixes just for cloudfront which worked: https://github.com/chapulina/docs/runs/977501187?check_suite_focus=true

I also set the following secrets on this repo:

* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`
* `CLOUDFRONT_DISTRIBUTION_ID`
* `IGN_VERSION_PASSWORD`

