### PR TITLE
Added description to tutorials and added a tutorials.yaml

### DIFF
--- a/acropolis/index.yaml
+++ b/acropolis/index.yaml
@@ -18,9 +18,12 @@ pages:
   - name: install
     title: Install
     file: install.md
+    description: Citadel Installation instructions
   - name: ros_integration
     title: ROS Integration
     file: ros_integration.md
+    description: This tutorial details how to interface with ROS, enabling the ability to use tools such as Rviz for robot or sensor visualization.
   - name: comparison
     title: Feature Comparison
     file: comparison.md
+    description: A list of features present in Gazebo-classic and the status of their migration to Ignition.

--- a/acropolis/index.yaml
+++ b/acropolis/index.yaml
@@ -18,7 +18,7 @@ pages:
   - name: install
     title: Install
     file: install.md
-    description: Citadel Installation instructions
+    description: Citadel installation instructions
   - name: ros_integration
     title: ROS Integration
     file: ros_integration.md

--- a/blueprint/index.yaml
+++ b/blueprint/index.yaml
@@ -18,21 +18,28 @@ pages:
   - name: install
     title: Install
     file: install.md
+    description: Blueprint Installation instructions
   - name: ros_integration
     title: ROS Integration
     file: ros_integration.md
+    description: This tutorial details how to interface with ROS, enabling the ability to use tools such as Rviz for robot or sensor visualization.
   - name: comparison
     title: Feature Comparison
     file: comparison.md
+    description: A list of features present in Gazebo-classic and the status of their migration to Ignition.
   - name: gui
     title: Understanding the GUI
     file: GUI_tutorial.md
+    description: This guide is an introduction to the Ignition Graphical User Interface (GUI).
   - name: manipulating_models
     title: Manipulating Models
     file: Manipulating_models.md
+    description: This tutorial will walk you through using various plugins to assist model and scene manipulation in the Ignition GUI.
   - name: fuel_insert
     title: Model Insertion from Fuel
     file: Model_insertion_fuel.md
+    description: Ignition Fuel hosts hundreds of models that can easily be added to a world running in the Ignition GUI.
   - name: hotkeys
     title: Keyboard Shortcuts
     file: hotkeys.md
+    description: Ignition keyboard shortcuts

--- a/blueprint/index.yaml
+++ b/blueprint/index.yaml
@@ -18,7 +18,7 @@ pages:
   - name: install
     title: Install
     file: install.md
-    description: Blueprint Installation instructions
+    description: Blueprint installation instructions
   - name: ros_integration
     title: ROS Integration
     file: ros_integration.md

--- a/citadel/index.yaml
+++ b/citadel/index.yaml
@@ -18,7 +18,7 @@ pages:
   - name: install
     title: Install
     file: install.md
-    description: Citadel Installation instructions
+    description: Citadel installation instructions
     children:
       - name: install_ubuntu
         title: Binary Ubuntu Install

--- a/citadel/index.yaml
+++ b/citadel/index.yaml
@@ -18,6 +18,7 @@ pages:
   - name: install
     title: Install
     file: install.md
+    description: Citadel Installation instructions
     children:
       - name: install_ubuntu
         title: Binary Ubuntu Install
@@ -34,18 +35,24 @@ pages:
   - name: ros_integration
     title: ROS Integration
     file: ros_integration.md
+    description: This tutorial details how to interface with ROS, enabling the ability to use tools such as Rviz for robot or sensor visualization.
   - name: comparison
     title: Feature Comparison
     file: comparison.md
+    description: A list of features present in Gazebo-classic and the status of their migration to Ignition.
   - name: gui
     title: Understanding the GUI
     file: GUI_tutorial.md
+    description: This guide is an introduction to the Ignition Graphical User Interface (GUI).
   - name: manipulating_models
     title: Manipulating Models
     file: Manipulating_models.md
+    description: This tutorial will walk you through using various plugins to assist model and scene manipulation in the Ignition GUI.
   - name: fuel_insert
     title: Model Insertion from Fuel
     file: Model_insertion_fuel.md
+    description: Ignition Fuel hosts hundreds of models that can easily be added to a world running in the Ignition GUI.
   - name: hotkeys
     title: Keyboard Shortcuts
     file: hotkeys.md
+    description: Ignition keyboard shortcuts

--- a/tutorials.yaml
+++ b/tutorials.yaml
@@ -1,0 +1,8 @@
+# This file is an index of the pages to display on the documentation website
+# (https://ignitionrobotics.org/tutorials). The order of the pages in this file
+# is reflected on the website's left sidebar.
+
+releases:
+  - citadel
+  - blueprint
+  - acropolis


### PR DESCRIPTION
This PR is related to this issue https://github.com/ignitionrobotics/docs/issues/55 and with these others PR: 
 - https://gitlab.com/ignitionrobotics/web/web-server/-/merge_requests/12
 - https://gitlab.com/ignitionrobotics/web/web/-/merge_requests/15

This PR includes:
 - Added `tutorial.yaml` file to get all the tutorials under the releases specified in this file.  
 - Added description for all the tutorials

Signed-off-by: ahcorde <ahcorde@gmail.com>