### PR TITLE
Update Releases link

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -87,7 +87,7 @@ and release pattern allows us to distribute patch and minor updates into an alre
 
 ## Planned releases
 
-Please see the [Releases](/docs/releases) for the timeline of and information about future distributions.
+Please see the [Releases](/docs/all/releases) for the timeline of and information about future distributions.
 
 ## Contributing to Ignition
 


### PR DESCRIPTION
the previous link of /docs/releases was to a blank page. Updated to docs/all/releases