### PR TITLE
Periodic labeler and no-fail triage

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - uses: actions/labeler@v2
       with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,13 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
-
+  schedule:
+    - cron: '*/20 * * * *'
 jobs:
-  triage:
+  labeler:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
-    - uses: actions/labeler@v2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: ignition-tooling/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,6 +8,7 @@ jobs:
   assign:
     name: Add ticket to inbox
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Add ticket to inbox
         uses: technote-space/create-project-card-action@v1


### PR DESCRIPTION
Resolves #35.

GitHub actions is very limited when it comes to forks, so both our labeler and triage always fail due to lack of permissions.

Here we use a periodic labeler to overcome that.

I haven't found a good alternative for the triage yet, so I'm just preventing it from failing CI.

