### PR TITLE
Citadel install and tutorial updates

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -144,7 +144,8 @@ sudo apt-get install -y \
   ruby-dev \
   ruby-ronn \
   swig \
-  uuid-dev
+  uuid-dev \
+  build-essential
 ```
 
 Additionally, on Ubuntu Bionic:

--- a/citadel/ros_integration.md
+++ b/citadel/ros_integration.md
@@ -24,7 +24,14 @@ to verify if your message type is supported by the bridge.
 **Not available at the moment**
 
 The repository `packages.osrfoundation.org` hosts binary packages for Blueprint
-but for Citadel the recommended method is to build from source
+but for Citadel the recommended method is to build from source.
+
+For users using ROS Noetic on Ubuntu Focal, a binary deb is available for Citadel:
+
+```bash
+sudo apt install ros-noetic-ros-ign
+
+```
 
 ## Source install
 

--- a/citadel/ros_integration.md
+++ b/citadel/ros_integration.md
@@ -74,8 +74,10 @@ setup.bash (not needed for binary packages):
 
 ```bash
 # Shell D:
-. ~/bridge_ws/install/setup.bash
+. ~/workspace/install/setup.bash
 ```
+
+**Note**: The `workspace` directory is the name of the workspace you created (e.g., in [Ubuntu Source Install](install_ubuntu_src)), which can be named anything.
 
 Run the bridge:
 


### PR DESCRIPTION
Updates to Citadel install from source instructions and clarified information in ROS Integration tutorial.