### PR TITLE
Fix broken link to citadel tutorials from Getting Started page

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -72,7 +72,7 @@ custom SDF file.
 ## Step 4: Explore and learn
 
 This tutorial has covered the basics of getting started with Ignition.
-Starting with Citadel, there are more [versioned tutorials](docs/citadel/tutorials)
+Starting with Citadel, there are more [versioned tutorials](/docs/citadel/tutorials)
 covering the basics of the GUI, creating worlds and robots, and more.
 
 Each [Ignition library](/libs) also has a set of tutorials and


### PR DESCRIPTION
https://ignitionrobotics.org/docs/all/getstarted#step-4-explore-and-learn `versioned tutorials` links to a page that does not exist

```
https://ignitionrobotics.org/docs/all/docs/citadel/tutorials
```

It looks like the relative link is the problem. [Adding a leading slash](https://www.w3schools.com/html/html_filepaths.asp) should make it resolve to the correct page.

```
https://ignitionrobotics.org/docs/citadel/tutorials
```