### PR TITLE
Ignition Edifice: roadmap, installation, info

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,6 @@
 🔮 dome:
   - dome/*
   - dome/**/*
+🏢 edifice:
+  - edifice/*
+  - edifice/**/*

--- a/dome/install.md
+++ b/dome/install.md
@@ -2,7 +2,7 @@
 
 Dome supports the following platforms:
 
- * Ubuntu Bionic and Focal on amd64/i386
+ * Ubuntu Bionic amd64/arm64/i386 and Focal on amd64/arm64
  * MacOS Mojave and Catalina
      * Ignition currently only works in headless mode
       (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use

--- a/dome/install.md
+++ b/dome/install.md
@@ -16,7 +16,7 @@ contains some tips for Windows.
 
 ## Binary installation instructions
 
-Nightly builds are available for Linux.
+Binary builds are available for Linux and macOS.
 
  * [Binary Installation on Ubuntu](install_ubuntu)
  * [Binary Installation on MacOS](install_osx)
@@ -32,8 +32,6 @@ Source installation is recommended for users planning on altering Ignition's sou
 
 The Dome collection is composed of many different Ignition libraries. The
 collection assures that all libraries are compatible and can be used together.
-
-This list of library versions may change up to the release date.
 
 | Library name       | Version       |
 | ------------------ |:-------------:|

--- a/edifice/index.yaml
+++ b/edifice/index.yaml
@@ -1,0 +1,34 @@
+# This file is an index of the pages to display on the documentation website
+# (https://ignitionrobotics.org/docs). The order of the pages in this file
+# is reflected on the website's left sidebar.
+#
+# Components of the index:
+#
+# 1. "pages:" The master list of pages
+#
+# 2. Each page has a
+#    a. "name:" This should be a short url-friendly and unique name. It will
+#    be used in the website url.
+#
+#    b. "title:" This is a human-friendly title for the page. This title will
+#    be displayed on the website's left side bar.
+#
+#    c. "file:" The markdown file that contains the page's content.
+pages:
+  - name: install
+    title: Install
+    file: install.md
+    description: Edifice installation instructions
+    children:
+      - name: install_ubuntu
+        title: Binary Ubuntu Install
+        file: install_ubuntu.md
+      - name: install_osx
+        title: Binary OSX Install
+        file: install_osx.md
+      - name: install_ubuntu_src
+        title: Ubuntu Source Install
+        file: install_ubuntu_src.md
+      - name: install_osx_src
+        title: OSX Source Install
+        file: install_osx_src.md

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -1,0 +1,47 @@
+# Edifice Installation
+
+Ignition Edifice is under active development and will be officially released on
+March 2021. If you'd like to use a stable release, see
+[Citadel](/docs/citadel).
+
+Until the official release, Edifice can be compiled from source or installed
+from nightly debian packages on Linux.
+
+## Binary installation instructions
+
+Nightly builds are available for Linux and macOS.
+
+ * [Binary Installation on Ubuntu](install_ubuntu)
+ * [Binary Installation on MacOS](install_osx)
+
+## Source Installation instructions
+
+Source installation is recommended for users planning on altering Ignition's source code (advanced).
+
+ * [Source Installation on Ubuntu](install_ubuntu_src)
+ * [Source Installation on MacOS](install_osx_src)
+
+## Edifice Libraries
+
+The Edifice collection is composed of many different Ignition libraries. The
+collection assures that all libraries are compatible and can be used together.
+
+This list of library versions may change up to the release date.
+
+| Library name       | Version       |
+| ------------------ |:-------------:|
+|   ign-cmake        |       2.x     |
+|   ign-common       |       3.x     |
+|   ign-fuel-tools   |       5.x     |
+|   ign-gazebo       |       4.x     |
+|   ign-gui          |       4.x     |
+|   ign-launch       |       3.x     |
+|   ign-math         |       6.x     |
+|   ign-msgs         |       6.x     |
+|   ign-physics      |       3.x     |
+|   ign-plugin       |       1.x     |
+|   ign-rendering    |       4.x     |
+|   ign-sensors      |       4.x     |
+|   ign-tools        |       1.x     |
+|   ign-transport    |       9.x     |
+|   sdformat         |      10.x     |

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -2,14 +2,14 @@
 
 Ignition Edifice is under active development and will be officially released on
 March 2021. If you'd like to use a stable release, see
-[Citadel](/docs/citadel).
+[Dome](/docs/dome).
 
 Until the official release, Edifice can be compiled from source or installed
 from nightly debian packages on Linux.
 
 ## Binary installation instructions
 
-Nightly builds are available for Linux and macOS.
+Nightly builds are available for Linux (Ubuntu Focal and Bionic on amd64) and macOS.
 
  * [Binary Installation on Ubuntu](install_ubuntu)
  * [Binary Installation on MacOS](install_osx)

--- a/edifice/install_osx.md
+++ b/edifice/install_osx.md
@@ -1,0 +1,33 @@
+# Binary Installation on MacOS
+
+All the Edifice binaries are available in Mojave and Catalina using the
+[homebrew package manager](https://brew.sh/).
+
+Up to Edifice's release date, the binaries should be considered unstable.
+
+The homebrew tool can be installed using:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
+After installing the homebrew package manager, Ignition Edifice can be installed running:
+
+```bash
+brew tap osrf/simulation
+brew install ignition-edifice
+```
+
+All libraries should be ready to use and the `ign gazebo` app ready to be executed.
+
+Head back to the [Getting started](/docs/all/get_started)
+page to start using Ignition!
+
+## Uninstalling binary install
+
+If you need to uninstall Ignition or switch to a source-based install once you
+have already installed the library from binaries, run the following command:
+
+```bash
+brew uninstall ignition-edifice
+```

--- a/edifice/install_osx_src.md
+++ b/edifice/install_osx_src.md
@@ -1,0 +1,296 @@
+# Source Installation on MacOS
+
+This tutorial will work for MacOS Mojave 10.14 and MacOS Catalina 10.15.
+
+## Install tools
+
+The use of some additional tools is recommended to help with the source compilation,
+although other ways of correctly getting and building the sources are also possible.
+
+The easiest way to get the sources of all libraries is to use
+[vcstool](https://github.com/dirk-thomas/vcstool).
+
+To compile all the different libraries and ign-gazebo in the right order
+[colcon](https://colcon.readthedocs.io/en/released/) is recommended.
+The colcon tool is available on all platforms using pip (or pip3, if pip fails).
+
+## Python3 from homebrew
+
+Tools and dependencies for Edifice can be installed using the [homebrew package manager](https://brew.sh/).
+The homebrew tool can be installed by entering the following in a terminal:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
+Edifice is compatible with Python3; it can be installed by running the following in a terminal:
+
+```bash
+brew install python3
+```
+
+## vcstool and colcon from pip
+
+PIP is available on all platforms:
+
+```bash
+python3 -m pip install vcstool
+```
+
+```bash
+python3 -m pip install -U colcon-common-extensions
+```
+
+## Getting the sources
+
+The first step is to create a developer workspace in which `vcstool` and
+`colcon` can work:
+
+```bash
+mkdir -p ~/workspace/src
+cd ~/workspace/src
+```
+
+All the sources of ignition-edifice are declared in a yaml file. Download
+it to the workspace:
+
+```bash
+wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-edifice.yaml
+```
+
+Use `vcstool` to automatically retrieve all the Ignition libraries sources from
+their repositories:
+
+```bash
+vcs import < collection-edifice.yaml
+```
+
+The src subdirectory should contain all the sources ready to be built.
+
+
+## Install dependencies
+
+Add `osrf/simulation` to Homebrew formulae
+
+```bash
+brew update
+brew tap osrf/simulation
+```
+
+Install all dependencies:
+
+Dependency for Ogre:
+
+```bash
+brew cask install xquartz
+```
+
+General dependencies:
+
+```bash
+brew install assimp boost bullet cmake cppzmq dartsim@6.10.0 doxygen eigen fcl ffmpeg flann freeimage freetype gflags google-benchmark gts ipopt irrlicht jsoncpp libccd libyaml libzzip libzip nlopt ode open-scene-graph ossp-uuid ogre1.9 ogre2.1 pkg-config protobuf qt qwt rapidjson ruby tbb tinyxml tinyxml2 urdfdom zeromq
+```
+
+`dartsim@6.10.0` and `qt5` are not sym-linked. To use those dependencies when building
+`ignition-physics2` and `ignition-gui3`, run the following after installation to add them to `/use/local`:
+
+```bash
+# dartsim@6.10.0
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/dartsim@6.10.0
+export DYLD_FALLBACK_LIBRARY_PATH=${DYLD_FALLBACK_LIBRARY_PATH}:/usr/local/opt/dartsim@6.10.0/lib:/usr/local/opt/octomap/local
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/dartsim@6.10.0/lib/pkgconfig
+# qt5
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/qt
+```
+
+### Install compiler requirements
+
+The Ignition Libraries require the Xcode 10 compiler on MacOS Mojave.
+
+On Mac machines, gcc is acquired by installing Xcode command line tools.
+The required version of Xcode for Edifice is Xcode 10.3, which can be downloaded from
+[Apple Developer Site](https://developer.apple.com/download/more/).
+You will need to sign in to your Apple account and download the Mojave version of
+Xcode command line tools. Command line tools can also be obtained by downloading
+Xcode from the Apple App Store (installing the full app may take over an hour).
+
+## Building the Ignition Libraries in MacOS Catalina (10.15)
+
+If you want to compile Ignition Libraries in MacOS Catalina (10.15) you will need to apply some patches in your filesystem:
+
+ - `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Ruby.framework/Headers/ruby/ruby/intern.h`
+
+Create a file called `intern.patch` with the following content:
+
+```patch
+--- intern.h    2019-12-16 18:17:08.000000000 +0100
++++ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Ruby.framework/Headers/ruby/ruby/intern.h
+@@ -14,6 +14,10 @@
+ #ifndef RUBY_INTERN_H
+ #define RUBY_INTERN_H 1
+
++#if __cplusplus > 199711L
++#define register      // Deprecated in C++11.
++#endif  // #if __cplusplus > 199711L
++
+ #if defined(__cplusplus)
+ extern "C" {
+ #if 0
+```
+
+Now we can apply the patch:
+
+```{.sh}
+sudo patch -p0 < intern.patch
+```
+
+ - `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Ruby.framework/Headers/ruby/ruby/config.h`
+
+Create a file called `config.patch` with the following content:
+
+```
+--- config.h    2019-12-16 18:19:13.000000000 +0100
++++ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Ruby.framework/Headers/ruby/ruby/config.h
+@@ -410,6 +410,6 @@
+ #define RUBY_PLATFORM_CPU "x86_64"
+ #endif /* defined __x86_64__ &&! defined RUBY_PLATFORM_CPU */
+ #define RUBY_PLATFORM_OS "darwin19"
+-#define RUBY_ARCH"universal-"RUBY_PLATFORM_OS
+-#define RUBY_PLATFORM"universal."RUBY_PLATFORM_CPU"-"RUBY_PLATFORM_OS
++#define RUBY_ARCH "universal-" RUBY_PLATFORM_OS
++#define RUBY_PLATFORM "universal." RUBY_PLATFORM_CPU "-" RUBY_PLATFORM_OS
+ #endif /* INCLUDE_RUBY_CONFIG_H */
+```
+
+Now we can appply the patch:
+
+```{.sh}
+sudo patch -p0 < config.patch
+```
+
+## Building the Ignition Libraries
+
+Once the compiler and all the sources are in place it is time to compile them.
+Start the procedure by changing into the workspace and listing the packages
+recognized by `colcon`:
+
+```bash
+cd ~/workspace/
+colcon graph
+```
+
+`colcon graph` should list the Ignition libraries with an
+[interdependency diagram](https://colcon.readthedocs.io/en/released/reference/verb/graph.html#example-output).
+If that is the case, then you are ready
+to build the whole set of libraries:
+
+```bash
+colcon build --merge-install
+```
+
+To speed up the build process, you could also disable tests by using
+
+```bash
+colcon build --cmake-args -DBUILD_TESTING=OFF --merge-install
+```
+
+To build a specific package with all its dependent packages:
+
+```bash
+colcon build --merge-install --packages-up-to PACKAGE_NAME
+```
+
+To build a single package:
+
+```bash
+colcon build --merge-install --packages-select PACKAGE_NAME
+```
+
+Visit [colcon documentation](https://colcon.readthedocs.io/en/released/#) to view more `colcon` build and test options.
+
+If there are no errors, all the binaries should be ready to use.
+
+## Using the workspace
+
+The workspace needs to be sourced every time a new terminal is used.
+
+Run the following command to source the workspace in bash:
+
+```bash
+. ~/workspace/install/setup.bash
+```
+
+Or in zsh:
+
+```zsh
+. ~/workspace/install/setup.zsh
+```
+
+This is the end of the source install instructions; head back to the [Getting started](getting_started.html)
+page to start using Ignition!
+
+## Uninstalling source-based install
+
+If you need to uninstall Ignition or switch to a binary-based install once you
+have already installed the library from source, navigate to your source code
+directory's build folders and run `make uninstall`:
+
+```bash
+cd /workspace
+sudo make uninstall
+```
+
+## Troubleshooting
+
+### Unable to find `urdf_model.h` error
+
+After installing all the dependencies and starting the build process, you may encounter an error that looks like this:
+
+```bash
+/Users/user/edifice_ws/src/sdformat/src/parser_urdf.cc:30:10: fatal error: 'urdf_model/model.h' file not found
+#include <urdf_model/model.h>
+         ^~~~~~~~~~~~~~~~~~~~
+1 error generated.
+make[2]: *** [src/CMakeFiles/sdformat9.dir/parser_urdf.cc.o] Error 1
+make[1]: *** [src/CMakeFiles/sdformat9.dir/all] Error 2
+make: *** [all] Error 2
+Failed   <<< sdformat9	[ Exited with code 2 ]
+```
+
+First check if `urdfdom` and `urdfdom_headers` are installed by running:
+
+```bash
+brew install urdfdom urdfdom_headers
+```
+
+Then if the error persists, compile with the internal version of `urdfdom` by running:
+
+```bash
+colcon build --cmake-args -DUSE_INTERNAL_URDF=ON --merge-install
+```
+
+This command will ignore the system installation of `urdfdom` and use the internal version instead.
+
+### Unable to load .dylib file
+
+When running the `ign gazebo -s` command, an error like the one below may show up:
+
+```bash
+Error while loading the library [/Users/edifice/edifice_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib]: dlopen(/Users/edifice/edifice_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib, 5): Library not loaded: @rpath/libIrrXML.dylib
+  Referenced from: /usr/local/opt/assimp/lib/libassimp.5.dylib
+  Reason: image not found
+[Err] [Physics.cc:275] Unable to load the /Users/edifice/edifice_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib library.
+Escalating to SIGKILL on [Ignition Gazebo Server]
+```
+
+The issue is related to OSX System Integrity Protection(SIP). The workaround is to run `ign` with a different ruby then make sure that ruby is loaded.
+
+```bash
+brew install ruby
+
+# Add the following to ~/.bashrc
+export PATH=/usr/local/Cellar/ruby/2.6.5/bin:$PATH
+
+# Source ~/.bashrc in terminal
+. ~/.bashrc
+```

--- a/edifice/install_ubuntu.md
+++ b/edifice/install_ubuntu.md
@@ -1,11 +1,12 @@
 # Binary Installation on Ubuntu
 
-Dome binaries are provided for Ubuntu Bionic and Focal. All of the Dome
+Edifice nightlies are provided for Ubuntu Bionic and Focal. All of the Edifice
 binaries are hosted in the osrfoundation repository. To install all of them,
-the metapackage `ignition-dome` can be installed:
+the metapackage `ignition-edifice` can be installed:
 
 ```bash
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install ignition-dome
@@ -22,6 +23,5 @@ If you need to uninstall Ignition or switch to a source-based install once you
 have already installed the library from binaries, run the following command:
 
 ```bash
-sudo apt remove ignition-dome && sudo apt autoremove
+sudo apt remove ignition-edifice && sudo apt autoremove
 ```
-

--- a/edifice/install_ubuntu.md
+++ b/edifice/install_ubuntu.md
@@ -1,0 +1,27 @@
+# Binary Installation on Ubuntu
+
+Dome binaries are provided for Ubuntu Bionic and Focal. All of the Dome
+binaries are hosted in the osrfoundation repository. To install all of them,
+the metapackage `ignition-dome` can be installed:
+
+```bash
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install ignition-dome
+```
+
+All libraries should be ready to use and the `ign gazebo` app ready to be executed.
+
+Head back to the [Getting started](/docs/all/get_started)
+page to start using Ignition!
+
+## Uninstalling binary install
+
+If you need to uninstall Ignition or switch to a source-based install once you
+have already installed the library from binaries, run the following command:
+
+```bash
+sudo apt remove ignition-dome && sudo apt autoremove
+```
+

--- a/edifice/install_ubuntu.md
+++ b/edifice/install_ubuntu.md
@@ -9,7 +9,7 @@ sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `ls
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install ignition-dome
+sudo apt-get install ignition-edifice
 ```
 
 All libraries should be ready to use and the `ign gazebo` app ready to be executed.

--- a/edifice/install_ubuntu_src.md
+++ b/edifice/install_ubuntu_src.md
@@ -1,0 +1,251 @@
+# Source Installation on Ubuntu
+
+These instructions apply to Ubuntu Bionic or Focal.
+
+## Install tools
+
+The use of some additional tools is recommended to help with the source compilation,
+although other ways of correctly getting and building the sources are also possible.
+
+The easiest way to get the sources of all libraries is to use
+[vcstool](https://github.com/dirk-thomas/vcstool).
+
+To compile all the different libraries and ign-gazebo in the right order
+[colcon](https://colcon.readthedocs.io/en/released/) is recommended.
+The colcon tool is available on all platforms using pip (or pip3, if pip fails).
+
+Some tools require Python 3.5 (or higher) which is not the default option on some
+platforms (like Ubuntu Focal). The Python
+[virtualenv](https://virtualenv.pypa.io/en/latest/) could be a useful solution in
+cases where the default option cannot be easily changed.
+
+## vcstool and colcon from pip
+
+PIP is available on all platforms:
+
+```bash
+pip install vcstool
+```
+
+```bash
+pip install -U colcon-common-extensions
+```
+
+Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
+
+## vcstool and colcon from apt
+
+An alternative method is to use the `.deb` packages available on Debian or Ubuntu:
+
+```bash
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo -E apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+sudo apt-get update
+sudo apt-get install python3-vcstool python3-colcon-common-extensions
+```
+
+## Git
+
+Ignition libraries use `git` for version control, so it must be available
+in the system for `vcstool` to work properly.
+
+```bash
+sudo apt-get install git
+```
+
+## Getting the sources
+
+The instructions below use some UNIX commands to manage directories but the
+equivalent alternatives on Windows should provide the same result.
+
+The first step is to create a developer workspace in which `vcstool` and
+`colcon` can work:
+
+```bash
+mkdir -p ~/workspace/src
+cd ~/workspace/src
+```
+
+All the sources of ignition-edifice are declared in a yaml file. Download
+it to the workspace:
+
+```bash
+wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-edifice.yaml
+```
+
+Use `vcstool` to automatically retrieve all the Ignition libraries sources from
+their repositories:
+
+```bash
+vcs import < collection-edifice.yaml
+```
+
+The src subdirectory should contain all the sources ready to be built.
+
+## Install dependencies
+
+Before compiling it is necessary to install all the dependencies of the different
+packages that compose the Edifice collection. Every platform has a different
+method to install software dependencies.
+
+Add `packages.osrfoundation.org` to the apt sources list:
+
+```bash
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo apt-get update
+```
+
+The command below will install all dependencies in Ubuntu Bionic or Focal:
+
+```bash
+SYSTEM_VERSION=`lsb_release -cs`
+sudo apt -y install \
+  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+```
+
+### Install compiler requirements
+
+The Ignition Libraries require the gcc compiler version 8 or higher.
+(Windows requires Visual Studio 2019).
+
+#### Ubuntu Bionic
+
+Ubuntu Bionic's default compiler version is not high enough, so the following
+steps are needed to upgrade. These are not needed on Ubuntu Focal.
+
+To install `gcc` version 8 on Ubuntu Bionic:
+
+```bash
+sudo apt-get install g++-8
+```
+
+Set `gcc-8` and `g++-8` to be the default compilers.
+
+```bash
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+```
+
+At this point `gcc`  and `g++` should both report version 8. Test this with
+the following commands.
+
+```bash
+gcc -v
+g++ -v
+```
+
+## Building the Ignition Libraries
+
+Once the compiler and all the sources are in place it is time to compile them.
+Start the procedure by changing into the workspace and listing the packages
+recognized by `colcon`:
+
+```bash
+cd ~/workspace/
+colcon graph
+```
+
+`colcon graph` should list the Ignition libraries with an
+[interdependency diagram](https://colcon.readthedocs.io/en/released/reference/verb/graph.html#example-output).
+If that is the case, then you are ready
+to build the whole set of libraries:
+
+```bash
+colcon build --merge-install
+```
+
+To speed up the build process, you could also disable tests by using
+
+```bash
+colcon build --cmake-args -DBUILD_TESTING=OFF --merge-install
+```
+
+To build a specific package with all its dependent packages:
+
+```bash
+colcon build --merge-install --packages-up-to PACKAGE_NAME
+```
+
+To build a single package:
+
+```bash
+colcon build --packages-select PACKAGE_NAME
+```
+
+Visit [colcon documentation](https://colcon.readthedocs.io/en/released/#) to view more `colcon` build and test options.
+
+If there are no errors, all the binaries should be ready to use.
+
+## Using the workspace
+
+The workspace needs to be sourced every time a new terminal is used.
+
+Run the following command to source the workspace in bash:
+
+```bash
+. ~/workspace/install/setup.bash
+```
+
+Or in zsh:
+
+```zsh
+. ~/workspace/install/setup.zsh
+```
+
+This is the end of the source install instructions; head back to the [Getting started](getting_started.html)
+page to start using Ignition!
+
+## Uninstalling source-based install
+
+A source-based install can be "uninstalled" using several methods, depending on
+the results you want:
+
+  1. If you installed your workspace with `colcon` as instructed above, "uninstalling"
+     could be just a matter of opening a new terminal and not sourcing the
+     workspace's `setup.sh`. This way, your environment will behave as though
+     there is no Ignition install on your system.
+
+  2. If, in addition to not wanting to use the libraries, you're also trying to
+     free up space, you can delete the entire workspace directory with:
+
+     ```bash
+     rm -rf ~/workspace
+     ```
+
+  3. If you want to keep the source code, you can remove the
+     `install` / `build` / `log` directories as desired, leaving the `src` directory.
+
+## Troubleshooting
+
+### Unable to create the rendering window
+
+If you're getting errors like "Unable to create the rendering window", it could
+mean you're using an old OpenGL version. Ignition Gazebo uses the Ogre 2
+rendering engine by default, which requires an OpenGL version higher than 3.3.
+
+This can be confirmed by checking the Ogre 2 logs at `~/.ignition/rendering/ogre2.log`,
+which should have an error like:
+
+"OGRE EXCEPTION(3:RenderingAPIException): OpenGL 3.3 is not supported. Please update your graphics card drivers."
+
+You can also check your OpenGL version running:
+
+    glxinfo | grep "OpenGL version"
+
+You should be able to use Ogre 1 without any issues however. You can check if
+that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+
+    ign gazebo -v 3 lights.sdf
+
+If that loads, you can continue to use Ignition with Ogre 1, just be sure to
+specify `ogre` in your SDF files instead of `ogre2`.
+
+To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
+As suggested on the Ogre logs, this may require updating your graphics card
+drivers.
+
+The Ogre 2 debs from the osrfoundation repository are built from a fork of
+Ogre's `v2-1` branch with changes needed for deb packaging and allowing it to
+be co-installable with Ogre 1.x. The code can be found here:
+
+https://github.com/osrf/ogre-2.1-release

--- a/index.yaml
+++ b/index.yaml
@@ -36,6 +36,10 @@ pages:
     file: contributing.md
     description: How to contribute to Ignition.
 releases:
+  - name: edifice
+    lts: false
+    eol: false
+    description: Upcoming release, under development.
   - name: dome
     lts: false
     eol: false

--- a/release_features.md
+++ b/release_features.md
@@ -58,6 +58,13 @@ collection assures that all libraries all compatible and can be used together.
 1. Integration of [Google benchmark](https://github.com/google/benchmark) for performance metrics and analysis.
 1. Tracked vehicle support.
 1. Breadcrumbs plugin.
+1. Position-based PID controller.
+1. Improved resource path handling.
+1. Loading custom physics engine plugins.
+1. Plugin that publishes a user specified message on an output topic in response to an input message.
+1. Noise for RGBD camera.
+1. Load worlds from Fuel.
+1. [Customizable GUI layout](https://ignitionrobotics.org/api/gazebo/3.3/gui_config.html).
 1. GUI tools:
     * GUI tools for model placement, and a new Scene Tree widget.
     * Translate and rotate models.
@@ -68,9 +75,14 @@ collection assures that all libraries all compatible and can be used together.
     * Delete model.
     * Grid.
     * Drag-and-drop models from Fuel to Ignition Gazebo UI.
-    * Preset view angles
-    * Hotkeys for transform modes and snapping
-    * Entity selection
+    * Preset view angles.
+    * Hotkeys for transform modes and snapping.
+    * Entity selection.
+    * [Align models](https://ignitionrobotics.org/docs/dome/manipulating_models#align-tool).
+    * Insert simple shapes.
+    * Insert models from online sources and local directories.
+    * Log playback scrubber.
+    * Save worlds.
 
 | Library name       | Version       | Changelog     |
 | ------------------ |:-------------:|:-------------:|
@@ -99,6 +111,11 @@ collection assures that all libraries all compatible and can be used together.
 1. Emissive texture maps.
 1. SDFormat frame semantics.
 1. Upload and delete models to Fuel from command line.
+1. Buoyancy model.
+1. [Trivial Physics Engine](https://community.gazebosim.org/t/announcing-new-physics-engine-tpe-trivial-physics-engine/629)
+1. Widget listing all transport topics.
+1. Widget that publishes keys pressed on the keyboard.
+1. [Tutorial series](https://community.gazebosim.org/t/gsoc-2020-new-ignition-gazebo-demos/613).
 
 | Library name       | Version       | Changelog     |
 | ------------------ |:-------------:|:-------------:|
@@ -117,4 +134,32 @@ collection assures that all libraries all compatible and can be used together.
 |   ign-tools        |       1.x     |       [Changelog](https://github.com/ignitionrobotics/ign-tools/blob/ign-tools1/Changelog.md)     |
 |   ign-transport    |       8.x     |       [Changelog](https://github.com/ignitionrobotics/ign-transport/blob/ign-transport8/Changelog.md)      |
 |   sdformat         |       9.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf9/Changelog.md)        |
+
+
+## Dome
+
+1. Particle effects on Ignition Rendering.
+1. Actor plugins.
+1. GUI tools:
+    * [Plotting](https://community.gazebosim.org/t/gsoc-2020-plotting-tool-for-ignition/619)
+    * [Lidar visualization](https://community.gazebosim.org/t/gsoc-2020-sensor-data-visualization/638)
+
+
+| Library name       | Version       | Changelog     |
+| ------------------ |:-------------:|:-------------:|
+|   ign-cmake        |       2.x     |       [Changelog](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/Changelog.md)     |
+|   ign-common       |       3.x     |       [Changelog](https://github.com/ignitionrobotics/ign-common/blob/ign-common3/Changelog.md)    |
+|   ign-fuel-tools   |       5.x     |       [Changelog](https://github.com/ignitionrobotics/ign-fuel-tools/blob/ign-fuel-tools5/Changelog.md)    |
+|   ign-gazebo       |       4.x     |       [Changelog](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/Changelog.md)     |
+|   ign-gui          |       4.x     |       [Changelog](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui4/Changelog.md)       |
+|   ign-launch       |       3.x     |       [Changelog](https://github.com/ignitionrobotics/ign-launch/blob/ign-launch3/Changelog.md)
+|   ign-math         |       6.x     |       [Changelog](https://github.com/ignitionrobotics/ign-math/blob/ign-math6/Changelog.md)
+|   ign-msgs         |       6.x     |       [Changelog](https://github.com/ignitionrobotics/ign-msgs/blob/ign-msgs6/Changelog.md)
+|   ign-physics      |       3.x     |       [Changelog](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics3/Changelog.md)
+|   ign-plugin       |       1.x     |       [Changelog](https://github.com/ignitionrobotics/ign-plugin/blob/ign-plugin1/Changelog.md)     |
+|   ign-rendering    |       4.x     |       [Changelog](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering4/Changelog.md)      |
+|   ign-sensors      |       4.x     |       [Changelog](https://github.com/ignitionrobotics/ign-sensors/blob/ign-sensors4/Changelog.md)      |
+|   ign-tools        |       1.x     |       [Changelog](https://github.com/ignitionrobotics/ign-tools/blob/ign-tools1/Changelog.md)     |
+|   ign-transport    |       9.x     |       [Changelog](https://github.com/ignitionrobotics/ign-transport/blob/ign-transport9/Changelog.md)      |
+|   sdformat         |       10.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf10/Changelog.md)        |
 

--- a/releases.md
+++ b/releases.md
@@ -18,5 +18,5 @@ An Ignition release follows the form "Ignition Codename", for example Ignition A
 | Blueprint  | May, 2019 | Dec, 2020 |       |
 | Citadel    | Dec, 2019 | Dec, 2024 | LTS   |
 | Dome       | Sep, 2020 | Dec, 2021 |       |
-| Ignition-E | Mar, 2021 | Mar, 2022 |       |
+| Edifice    | Mar, 2021 | Mar, 2022 |       |
 | Ignition-F | Sep, 2021 | Sep, 2026 | LTS   |

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ An Ignition release follows the form "Ignition Codename", for example Ignition A
 
 | Name       | Date      | EOL date  | Notes |
 |------------|-----------|-----------|-------|
-| Acropolis  | Feb, 2019 | Sep, 2019 |       |
+| Acropolis  | Feb, 2019 | Sep, 2019 | EOL   |
 | Blueprint  | May, 2019 | Dec, 2020 |       |
 | Citadel    | Dec, 2019 | Dec, 2024 | LTS   |
 | Dome       | Sep, 2020 | Dec, 2021 |       |

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,22 +10,22 @@ info@openrobotics.org.
 
 **Close the Gap** is Ignition's current focus topic. Over the next two
 quarters we will concentrate development efforts on topics that reduce
-feature disparity between Gazebo and Ignition and facilitate migration from
-Gazebo to Ignition. Take a look at the
+feature disparity between Gazebo classic and Ignition and facilitate migration from
+Gazebo classic to Ignition. Take a look at the
 [feature comparison](/docs/citadel/comparison) page for a list of
-differences between Gazebo and Ignition.
+differences between classic and Ignition.
 
 ## 2020 Q3(Jul - Sep)
 
 * **Migration Strategies**: Develop and document strategies for migrating
-plugins, SDF files, and other simulation resources from Gazebo to Ignition.
+plugins, SDF files, and other simulation resources from Gazebo classic to Ignition.
     * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22migration%22&state=open&type=Issues)
       with the "migration" label.
     * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22migration%22)
       for tickets with the "migration" label.
 
 * **Documentation**: Improve documentation release process and usability.
-Port relevant Gazebo tutorials to Ignition.
+Port relevant Gazebo classic tutorials to Ignition.
     * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22boost+the+docs%22&state=open&type=Issues)
       with the "boost the docs" label.
     * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22boost+the+docs%22)
@@ -41,7 +41,7 @@ Port relevant Gazebo tutorials to Ignition.
         * [All open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3AmacOS&type=Issues)
         * [Status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3AmacOS)
 
-* **Feature parity**: Port features from Gazebo that are missing in Ignition.
+* **Feature parity**: Port features from Gazebo classic that are missing in Ignition.
     * See [all open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22close+the+gap%22&state=open&type=Issues)
       with the "close the gap" label.
     * See [current development status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22close+the+gap%22)
@@ -71,7 +71,7 @@ and release pattern allows us to distribute patch and minor updates into an alre
 1. SDF website update, documentation, and model composition.
 1. Trajectory animation.
 1. Support custom rendering engines.
-1. New APIs to ease migration from Gazebo-classic.
+1. New APIs to ease migration from Gazebo classic.
 
 ### Dome
 
@@ -99,6 +99,6 @@ resources to get you going.
 
 1. [How to contribute](/docs/all/contributing) guide.
 1. [Feature comparision](/docs/citadel/comparison) list. This page lists the
-   feature gaps between Gazebo-classic and Ignition Gazebo.
+   feature gaps between Gazebo classic and Ignition Gazebo.
 1. Take a look at the various [libraries](/libs), and the issue tracker
    associated with each.

--- a/roadmap.md
+++ b/roadmap.md
@@ -62,28 +62,31 @@ and release pattern allows us to distribute patch and minor updates into an alre
 ### Blueprint
 
 1. Detachable joints.
-1. Buoyancy model.
 1. Additional graphical tools for model and world creation and editing.
-1. GUI tool to insert models from online sources and local directories.
 1. Audio sensor and source.
-1. Improved resource path handling.
-1. Loading custom physics engine plugins.
 
 ### Citadel
 
-1. Simplified physics engine.
 1. Bazel build files.
 1. SDF website update, documentation, and model composition.
 1. Trajectory animation.
+1. Support custom rendering engines.
+1. New APIs to ease migration from Gazebo-classic.
 
 ### Dome
 
 1. Particle effects, to support smoke and gas.
 1. Efficient skeleton animations.
 1. Localized wind (wind that is constrained to a region of influence).
-1. Design for Enhanced distributed simulation.
+1. Optical tactile plugin.
+1. Improved Ignition Physics documentation.
+
+### Edifice
+
+1. Improved Mac and Windows support
 1. OpenGL shaders to simulate underwater effects in camera sensors.
 1. Mesh level of detail support.
+1. Design for Enhanced distributed simulation.
 
 ## Planned releases
 


### PR DESCRIPTION
Add Edifice to the docs page, with installation instructions from nightlies and source.

Add Dome to the release features, and update other collections.

Also update roadmap for all collections.

Requires:

- [x] For debian nightlies: https://github.com/ignition-tooling/release-tools/pull/309
- [x] For mac binaries: https://github.com/osrf/homebrew-simulation/pull/1173
