### PR TITLE
Fix nightly uploads

### DIFF
--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -10,6 +10,8 @@
 set -o errexit
 set -o verbose
 
+DEBIAN_FRONTEND=noninteractive
+
 git clone https://github.com/$1/$2 -b $3
 cd $2
 

--- a/tools/scripts/install_common_deps.sh
+++ b/tools/scripts/install_common_deps.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o verbose
 
+DEBIAN_FRONTEND=noninteractive
+
 sudo apt-get update
 
 sudo apt-get install -y \


### PR DESCRIPTION
On https://github.com/ignitionrobotics/docs/pull/90/commits/1076bf26617a69c692ceee355ab704d13008d549 I reverted these changes because I thought they were redundant, but I never tested without them. It turns out they're needed, last night's nightly failed hanging at `tzdata`'s installation:

https://github.com/ignitionrobotics/docs/runs/1213147876?check_suite_focus=true