### PR TITLE
Non-periodic labeler using pull_request_target

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,11 @@
 name: "Pull Request Labeler"
 on:
-  schedule:
-    - cron: '*/20 * * * *'
+- pull_request_target
+
 jobs:
-  labeler:
+  triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: ignition-tooling/periodic-labeler@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          LABEL_MAPPINGS_FILE: .github/labeler.yml
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@ on:
 - pull_request_target
 
 jobs:
-  triage:
+  labeler:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v2

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:


### PR DESCRIPTION
Pull request #75 changed the on-PR-opened labeler to a periodic one due to a limitation on GitHub actions. However, GitHub [recently added](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) the `pull_request_target` event, which allows the regular labeler to work for PRs from forks.

This PR reverts to the original `actions/labeler`, but now using `pull_request_target`.