### PR TITLE
Add Windows tutorials to index

### DIFF
--- a/citadel/index.yaml
+++ b/citadel/index.yaml
@@ -24,14 +24,20 @@ pages:
         title: Binary Ubuntu Install
         file: install_ubuntu.md
       - name: install_osx
-        title: Binary OSX Install
+        title: Binary macOS Install
         file: install_osx.md
+      - name: install_windows
+        title: Binary Windows Install
+        file: install_windows.md
       - name: install_ubuntu_src
         title: Ubuntu Source Install
         file: install_ubuntu_src.md
       - name: install_osx_src
-        title: OSX Source Install
+        title: macOS Source Install
         file: install_osx_src.md
+      - name: install_windows_src
+        title: Windows Source Install
+        file: install_windows_src.md
       - name: troubleshooting
         title: Troubleshooting
         file: troubleshooting.md


### PR DESCRIPTION
The links are broken here:

https://ignitionrobotics.org/docs/citadel/install