### PR TITLE
Improve nightly doc upload: faster and easier to debug

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,9 +1,10 @@
 name: Upload docs to production
 
 on:
-  schedule:
-    # UTC timezone
-    - cron: '0 6 * * *'
+  push
+  # schedule:
+  #   # UTC timezone
+  #   - cron: '0 6 * * *'
 
 jobs:
   upload:

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,10 +1,9 @@
 name: Upload docs to production
 
 on:
-  push
-  # schedule:
-  #   # UTC timezone
-  #   - cron: '0 6 * * *'
+   schedule:
+     # UTC timezone
+     - cron: '0 6 * * *'
 
 jobs:
   upload:

--- a/tools/Dockerfile.citadel
+++ b/tools/Dockerfile.citadel
@@ -20,6 +20,7 @@ RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
 
+# See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0
@@ -28,6 +29,7 @@ RUN scripts/build_ign.sh ignitionrobotics ign-math ign-math6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
+# See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0
@@ -40,6 +42,8 @@ RUN scripts/build_ign.sh ignitionrobotics ign-common ign-common3 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
+# SDFormat's documentation is uploaded in a different way
+# Keeping it here for completeness
 # RUN scripts/build_ign.sh osrf sdformat sdf9 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0

--- a/tools/Dockerfile.citadel
+++ b/tools/Dockerfile.citadel
@@ -2,6 +2,8 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo ::group::Container setup
+
 RUN apt-get update \
  && apt-get install -y \
       sudo tzdata \
@@ -19,6 +21,8 @@ COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
+
+RUN echo ::endgroup::
 
 # See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \

--- a/tools/Dockerfile.citadel
+++ b/tools/Dockerfile.citadel
@@ -20,62 +20,62 @@ RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
 
-RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-math ign-math6 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-plugin ign-plugin1 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-common ign-common3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh osrf sdformat sdf9 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh osrf sdformat sdf9 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-msgs ign-msgs5 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-transport ign-transport8 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-fuel-tools ign-fuel-tools4 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-rendering ign-rendering3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-sensors ign-sensors3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-gui ign-gui3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-physics ign-physics2 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-gazebo ign-gazebo3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-launch ign-launch2 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0

--- a/tools/Dockerfile.dome
+++ b/tools/Dockerfile.dome
@@ -20,6 +20,7 @@ RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
 
+# See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0
@@ -28,6 +29,7 @@ RUN scripts/build_ign.sh ignitionrobotics ign-math ign-math6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
+# See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0
@@ -40,6 +42,8 @@ RUN scripts/build_ign.sh ignitionrobotics ign-common ign-common3 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
+# SDFormat's documentation is uploaded in a different way
+# Keeping it here for completeness
 # RUN scripts/build_ign.sh osrf sdformat sdf10 n \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0

--- a/tools/Dockerfile.dome
+++ b/tools/Dockerfile.dome
@@ -2,6 +2,8 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo ::group::Container setup
+
 RUN apt-get update \
  && apt-get install -y \
       sudo tzdata \
@@ -19,6 +21,8 @@ COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
+
+RUN echo ::endgroup::
 
 # See https://github.com/ignitionrobotics/docs/issues/53
 # RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \

--- a/tools/Dockerfile.dome
+++ b/tools/Dockerfile.dome
@@ -20,62 +20,62 @@ RUN scripts/enable_gcc8.sh
 
 COPY scripts/build_ign.sh scripts/build_ign.sh
 
-RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh ignitionrobotics ign-cmake ign-cmake2 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-math ign-math6 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh ignitionrobotics ign-tools ign-tools1 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-plugin ign-plugin1 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-common ign-common3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh osrf sdformat sdf10 n \
-      $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+# RUN scripts/build_ign.sh osrf sdformat sdf10 n \
+#       $IGN_VERSION_DATE \
+#       $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-msgs ign-msgs6 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-transport ign-transport9 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-fuel-tools ign-fuel-tools5 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-rendering ign-rendering4 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-sensors ign-sensors4 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-gui ign-gui4 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-physics ign-physics3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-gazebo ign-gazebo4 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0
 
 RUN scripts/build_ign.sh ignitionrobotics ign-launch ign-launch3 y \
       $IGN_VERSION_DATE \
-      $IGN_VERSION_PASSWORD
+      $IGN_VERSION_PASSWORD; exit 0

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,31 +29,23 @@ s3cmd --dump-config > s3.cfg
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
-  echo ::group::Acropolis
   echo -e "\e[46m\e[30mUploading documentation for Acropolis\e[0m\e[39m"
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
-  echo ::endgroup::
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
-  echo ::group::Blueprint
   echo -e "\e[46m\e[30mUploading documentation for Blueprint\e[0m\e[39m"
   docker build -t ign-blueprint-docs -f Dockerfile.blueprint --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
-  echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
-  echo ::group::Citadel
   echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
   docker build -t ign-citadel-docs -f Dockerfile.citadel --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
-  echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'dome' || $1 == 'Dome' ]]; then
-  echo ::group::Dome
   echo -e "\e[46m\e[30mUploading documentation for Dome\e[0m\e[39m"
   docker build -t ign-dome-docs -f Dockerfile.dome --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
-  echo ::endgroup::
 fi
 
 # Reminder to tic over cloudfront.

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,22 +29,22 @@ s3cmd --dump-config > s3.cfg
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
-  echo "Uploading documentation for Acropolis"
+  echo -e "[46mUploading documentation for Acropolis\e[0m"
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
-  echo "Uploading documentation for Blueprint"
+  echo -e "[46mUploading documentation for Blueprint\e[0m"
   docker build -t ign-blueprint-docs -f Dockerfile.blueprint --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
-  echo "Uploading documentation for Citadel"
+  echo -e "[46mUploading documentation for Citadel\e[0m"
   docker build -t ign-citadel-docs -f Dockerfile.citadel --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'all' || $1 == 'dome' || $1 == 'Dome' ]]; then
-  echo "Uploading documentation for Dome"
+  echo -e "[46mUploading documentation for Dome\e[0m"
   docker build -t ign-dome-docs -f Dockerfile.dome --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,22 +29,22 @@ s3cmd --dump-config > s3.cfg
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
-  echo -e "[46mUploading documentation for Acropolis\e[0m"
+  echo -e "[46m\e[90mUploading documentation for Acropolis\e[0m\e[39m"
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
-  echo -e "[46mUploading documentation for Blueprint\e[0m"
+  echo -e "[46m\e[90mUploading documentation for Blueprint\e[0m\e[39m"
   docker build -t ign-blueprint-docs -f Dockerfile.blueprint --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
-  echo -e "[46mUploading documentation for Citadel\e[0m"
+  echo -e "[46m\e[90mUploading documentation for Citadel\e[0m\e[39m"
   docker build -t ign-citadel-docs -f Dockerfile.citadel --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 
 if [[ $1 == 'all' || $1 == 'dome' || $1 == 'Dome' ]]; then
-  echo -e "[46mUploading documentation for Dome\e[0m"
+  echo -e "[46m\e[90mUploading documentation for Dome\e[0m\e[39m"
   docker build -t ign-dome-docs -f Dockerfile.dome --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
 fi
 

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,23 +29,31 @@ s3cmd --dump-config > s3.cfg
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
-  echo -e "[46m\e[90mUploading documentation for Acropolis\e[0m\e[39m"
+  echo ::group::Acropolis
+  echo -e "\e[46m\e[90mUploading documentation for Acropolis\e[0m\e[39m"
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
+  echo ::endgroup::
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
-  echo -e "[46m\e[90mUploading documentation for Blueprint\e[0m\e[39m"
+  echo ::group::Blueprint
+  echo -e "\e[46m\e[90mUploading documentation for Blueprint\e[0m\e[39m"
   docker build -t ign-blueprint-docs -f Dockerfile.blueprint --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
+  echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
-  echo -e "[46m\e[90mUploading documentation for Citadel\e[0m\e[39m"
+  echo ::group::Citadel
+  echo -e "\e[46m\e[90mUploading documentation for Citadel\e[0m\e[39m"
   docker build -t ign-citadel-docs -f Dockerfile.citadel --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
+  echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'dome' || $1 == 'Dome' ]]; then
-  echo -e "[46m\e[90mUploading documentation for Dome\e[0m\e[39m"
+  echo ::group::Dome
+  echo -e "\e[46m\e[90mUploading documentation for Dome\e[0m\e[39m"
   docker build -t ign-dome-docs -f Dockerfile.dome --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
+  echo ::endgroup::
 fi
 
 # Reminder to tic over cloudfront.

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -30,28 +30,28 @@ s3cmd --dump-config > s3.cfg
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
   echo ::group::Acropolis
-  echo -e "\e[46m\e[90mUploading documentation for Acropolis\e[0m\e[39m"
+  echo -e "\e[46m\e[30mUploading documentation for Acropolis\e[0m\e[39m"
   docker build -t ign-acropolis-docs -f Dockerfile.acropolis --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
   echo ::endgroup::
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
   echo ::group::Blueprint
-  echo -e "\e[46m\e[90mUploading documentation for Blueprint\e[0m\e[39m"
+  echo -e "\e[46m\e[30mUploading documentation for Blueprint\e[0m\e[39m"
   docker build -t ign-blueprint-docs -f Dockerfile.blueprint --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
   echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
   echo ::group::Citadel
-  echo -e "\e[46m\e[90mUploading documentation for Citadel\e[0m\e[39m"
+  echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
   docker build -t ign-citadel-docs -f Dockerfile.citadel --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
   echo ::endgroup::
 fi
 
 if [[ $1 == 'all' || $1 == 'dome' || $1 == 'Dome' ]]; then
   echo ::group::Dome
-  echo -e "\e[46m\e[90mUploading documentation for Dome\e[0m\e[39m"
+  echo -e "\e[46m\e[30mUploading documentation for Dome\e[0m\e[39m"
   docker build -t ign-dome-docs -f Dockerfile.dome --build-arg IGN_VERSION_PASSWORD --build-arg IGN_VERSION_DATE=`date -Iseconds` --no-cache .
   echo ::endgroup::
 fi

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -7,7 +7,6 @@
 # 5 - Release date in the ISO 8601 format. See the command `date -Iseconds`.
 # 6 - Password to https://api.ignitionrobotics.org/1.0/versions.
 
-set -o errexit
 set -o verbose
 
 export DEBIAN_FRONTEND=noninteractive
@@ -25,15 +24,18 @@ make doc
 
 if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Upload documentation
-  echo -e "\e[46mUpload documentation for $3\e[0m"
+  echo -e "\e[46m\e[90mUploading documentation for $3...\e[0m\e[39m"
   sh upload_doc.sh $4
+  echo -e "\e[46m\e[90mUploaded documentation for $3\e[0m\e[39m"
 
   # Get the project version from cmake
   version=`grep "project(.* VERSION" ../CMakeLists.txt  | grep -oP "(?<=VERSION )[0-9].[0-9].[0-9]"`
 
   # Get the libName from the second parameter
   libName=`echo "$2" | grep -oP "(?<=ign-).*"`
+  libName="${libName//-/_}
 
-  echo -e "\e[46mAdding version [$version] for library [$libName]\e[0m"
+  echo -e "\e[46m\e[90mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.ignitionrobotics.org/1.0/versions
+  echo -e "\e[46m\e[90mAdded version [$version] for library [$libName], release date [$5]\e[0m\e[39m"
 fi

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -26,9 +26,9 @@ cmake ../ -DBUILD_TESTING=false
 make doc
 echo ::endgroup::
 
+echo ::group::Upload documentation
 if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Upload documentation
-  echo ::group::Upload documentation
   echo -e "\e[46m\e[30mUploading documentation for $3...\e[0m\e[39m"
   sh upload_doc.sh $4
   echo -e "\e[46m\e[30mUploaded documentation for $3\e[0m\e[39m"
@@ -45,5 +45,5 @@ if [[ ! -z "$4" && "$4" != "n" ]]; then
   echo -e "\e[46m\e[30mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.ignitionrobotics.org/1.0/versions
   echo -e "\e[46m\e[30mAdded version [$version] for library [$libName], release date [$5]\e[0m\e[39m"
-  echo ::endgroup::
 fi
+echo ::endgroup::

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -21,11 +21,11 @@ sudo apt -y install \
 mkdir build
 cd build
 cmake ../ -DBUILD_TESTING=false
-sudo make install
+make doc
 
 if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Upload documentation
-  echo "Upload documentation for $3"
+  echo -e "\e[46mUpload documentation for $3\e[0m"
   sh upload_doc.sh $4
 
   # Get the project version from cmake
@@ -34,6 +34,6 @@ if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Get the libName from the second parameter
   libName=`echo "$2" | grep -oP "(?<=ign-).*"`
 
-  echo "Adding version [$version] for library [$libName]"
+  echo -e "\e[46mAdding version [$version] for library [$libName]\e[0m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.ignitionrobotics.org/1.0/versions
 fi

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -11,8 +11,9 @@ set -o verbose
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "\e[46m\e[90mProcessing [$1/$2] branch [$3]...\e[0m\e[39m"
+echo -e "\e[46m\e[30mProcessing [$1/$2] branch [$3]...\e[0m\e[39m"
 
+echo ::group::Clone and make
 git clone https://github.com/$1/$2 -b $3
 cd $2
 
@@ -23,21 +24,26 @@ mkdir build
 cd build
 cmake ../ -DBUILD_TESTING=false
 make doc
+echo ::endgroup::
 
 if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Upload documentation
-  echo -e "\e[46m\e[90mUploading documentation for $3...\e[0m\e[39m"
+  echo ::group::Upload documentation
+  echo -e "\e[46m\e[30mUploading documentation for $3...\e[0m\e[39m"
   sh upload_doc.sh $4
-  echo -e "\e[46m\e[90mUploaded documentation for $3\e[0m\e[39m"
+  echo -e "\e[46m\e[30mUploaded documentation for $3\e[0m\e[39m"
+  echo ::endgroup::
 
   # Get the project version from cmake
-  version=`grep "project(.* VERSION" ../CMakeLists.txt  | grep -oP "(?<=VERSION )[0-9].[0-9].[0-9]"`
+  echo ::group::Add version
+  version=`grep "project(.* VERSION" ../CMakeLists.txt  | grep -oP "(?<=VERSION )[0-9]*.[0-9]*.[0-9]*"`
 
   # Get the libName from the second parameter
   libName=`echo "$2" | grep -oP "(?<=ign-).*"`
   libName="${libName//-/_}"
 
-  echo -e "\e[46m\e[90mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
+  echo -e "\e[46m\e[30mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.ignitionrobotics.org/1.0/versions
-  echo -e "\e[46m\e[90mAdded version [$version] for library [$libName], release date [$5]\e[0m\e[39m"
+  echo -e "\e[46m\e[30mAdded version [$version] for library [$libName], release date [$5]\e[0m\e[39m"
+  echo ::endgroup::
 fi

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -11,6 +11,8 @@ set -o verbose
 
 export DEBIAN_FRONTEND=noninteractive
 
+echo -e "\e[46m\e[90mProcessing [$1/$2] branch [$3]...\e[0m\e[39m"
+
 git clone https://github.com/$1/$2 -b $3
 cd $2
 
@@ -33,7 +35,7 @@ if [[ ! -z "$4" && "$4" != "n" ]]; then
 
   # Get the libName from the second parameter
   libName=`echo "$2" | grep -oP "(?<=ign-).*"`
-  libName="${libName//-/_}
+  libName="${libName//-/_}"
 
   echo -e "\e[46m\e[90mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.ignitionrobotics.org/1.0/versions

--- a/tools/scripts/install_common_deps.sh
+++ b/tools/scripts/install_common_deps.sh
@@ -29,4 +29,5 @@ sudo apt-get install -y \
   ruby-dev \
   ruby-ronn \
   s3cmd \
-  software-properties-common
+  software-properties-common \
+  texlive-latex-base


### PR DESCRIPTION
The nightly uploads have been failing due to a lack of disk space. There are also several libraries that are not being uploaded. This consists of a series of fixes:

* Only `make doc` instead of `make`. This speeds up the job and reduces the required disk space. @nkoenig , do you remember why we didn't use `make doc` originally? Binaries are being installed anyway, so the libraries aren't counting on each-other's installed APIs for cross-linkage.
* Skip libraries that aren't using `ign-cmake` and thus don't have the `upload_docs` script: `ign-cmake`, `ign-tools`, `sdf`
* The `exit 0` allows the job to continue even if one library fails. They don't depend on each other, so there's no reason to stop.
* The `echo ::group::`s make the logs more organized
* Gave some color to the output so it's easier to go over the logs

**TODO**: revert changes to `.github/workflows/nightly-upload.yml` before merging. That just makes it faster to iterate.