### PR TITLE
Tweak Ubuntu source install

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -1,6 +1,6 @@
 # Source Installation on Ubuntu
 
-These instructions apply for Ubuntu Bionic (18.04) and Focal (20.04).
+These instructions apply to Ubuntu Bionic (18.04) and Focal (20.04).
 
 ## Install tools
 
@@ -19,17 +19,26 @@ platforms (like Ubuntu Bionic). The Python
 [virtualenv](https://virtualenv.pypa.io/en/latest/) could be a useful solution in
 cases where the default option cannot be easily changed.
 
+## Generic tools
+
+Install tools needed by this tutorial:
+
+```bash
+sudo apt install python3-pip wget lsb-release
+```
+
 ## vcstool and colcon from pip
 
 PIP is available on all platforms:
 
 ```bash
-pip install vcstool
+pip install vcstool || pip3 install vcstool
 ```
 
 ```bash
-pip install -U colcon-common-extensions
+pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensions
 ```
+
 Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
 
 ## vcstool and colcon from apt
@@ -95,75 +104,8 @@ sudo apt-get update
 The command below will install all dependencies in Ubuntu:
 
 ```bash
-sudo apt-get install -y \
-  build-essential \
-  cmake \
-  freeglut3-dev \
-  libavcodec-dev \
-  libavdevice-dev \
-  libavformat-dev \
-  libavutil-dev \
-  libbenchmark-dev \
-  libcurl4-openssl-dev \
-  libfreeimage-dev \
-  libgflags-dev \
-  libglew-dev \
-  libgts-dev \
-  libjsoncpp-dev \
-  libogre-1.9-dev \
-  libogre-2.1-dev \
-  libprotobuf-dev \
-  libprotobuf-dev \
-  libprotoc-dev \
-  libqt5core5a \
-  libsqlite3-dev \
-  libswscale-dev \
-  libtinyxml-dev \
-  libtinyxml2-dev \
-  libwebsockets-dev \
-  libyaml-dev \
-  libzip-dev \
-  libzmq3-dev \
-  pkg-config \
-  protobuf-compiler \
-  python \
-  qml-module-qt-labs-folderlistmodel \
-  qml-module-qt-labs-settings \
-  qml-module-qtqml-models2 \
-  qml-module-qtquick-controls \
-  qml-module-qtquick-controls2 \
-  qml-module-qtquick-dialogs \
-  qml-module-qtquick-layouts \
-  qml-module-qtquick2 \
-  qtbase5-dev \
-  qtdeclarative5-dev \
-  qtquickcontrols2-5-dev \
-  ruby \
-  ruby-dev \
-  ruby-ronn \
-  swig \
-  uuid-dev
-```
-
-Additionally, on Ubuntu Bionic:
-
-```bash
-sudo apt-get install -y \
-  dart6-data \
-  libdart6-collision-ode-dev \
-  libdart6-dev \
-  libdart6-utils-urdf-dev
-```
-
-Or additionally, on Ubuntu Focal:
-
-```bash
-sudo apt-get install -y \
-  libdart-collision-ode-dev \
-  libdart-dev \
-  libdart-external-ikfast-dev \
-  libdart-external-odelcpsolver-dev \
-  libdart-utils-urdf-dev
+sudo apt -y install \
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements

--- a/citadel/troubleshooting.md
+++ b/citadel/troubleshooting.md
@@ -77,30 +77,8 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 
     ign gazebo -v 3 lights.sdf
 
-If that loads, you can continue to use Ignition with Ogre 1, just be sure to
-specify `ogre` in your SDF files instead of `ogre2`.
-
-For this you need to edit the `gui` section in your SDF file:
-```
-<gui fullscreen="0">
-
-            <!-- 3D scene -->
-            <plugin filename="GzScene3D" name="3D View">
-                <ignition-gui>
-                <title>3D View</title>
-                <property type="bool" key="showTitleBar">false</property>
-                <property type="string" key="state">docked</property>
-                </ignition-gui>
-
-                <engine>ogre</engine> <!-- change ogre2 to ogre-->
-                <scene>scene</scene>
-                <ambient_light>0.4 0.4 0.4</ambient_light>
-                <background_color>0.8 0.8 0.8</background_color>
-            </plugin>
-     </gui>        
-
-```
-
+If that loads, you can continue to use Ignition with Ogre 1, just use the
+`--render-engine ogre` option.
 
 To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
 As suggested on the Ogre logs, this may require updating your graphics card

--- a/dome/install_ubuntu_src.md
+++ b/dome/install_ubuntu_src.md
@@ -1,6 +1,6 @@
 # Source Installation on Ubuntu
 
-These instructions apply to Ubuntu Bionic or Focal.
+These instructions apply to Ubuntu Bionic (18.04) and Focal (20.04).
 
 ## Install tools
 
@@ -19,16 +19,24 @@ platforms (like Ubuntu Focal). The Python
 [virtualenv](https://virtualenv.pypa.io/en/latest/) could be a useful solution in
 cases where the default option cannot be easily changed.
 
+## Generic tools
+
+Install tools needed by this tutorial:
+
+```bash
+sudo apt install python3-pip wget lsb-release
+```
+
 ## vcstool and colcon from pip
 
 PIP is available on all platforms:
 
 ```bash
-pip install vcstool
+pip install vcstool || pip3 install vcstool
 ```
 
 ```bash
-pip install -U colcon-common-extensions
+pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensions
 ```
 
 Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
@@ -99,9 +107,8 @@ sudo apt-get update
 The command below will install all dependencies in Ubuntu Bionic or Focal:
 
 ```bash
-SYSTEM_VERSION=`lsb_release -cs`
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements

--- a/dome/troubleshooting.md
+++ b/dome/troubleshooting.md
@@ -77,8 +77,8 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 
     ign gazebo -v 3 lights.sdf
 
-If that loads, you can continue to use Ignition with Ogre 1, just be sure to
-specify `ogre` in your SDF files instead of `ogre2`.
+If that loads, you can continue to use Ignition with Ogre 1, just use the
+`--render-engine ogre` option.
 
 To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
 As suggested on the Ogre logs, this may require updating your graphics card

--- a/edifice/index.yaml
+++ b/edifice/index.yaml
@@ -32,3 +32,6 @@ pages:
       - name: install_osx_src
         title: OSX Source Install
         file: install_osx_src.md
+      - name: troubleshooting
+        title: Troubleshooting
+        file: troubleshooting.md

--- a/edifice/install_ubuntu_src.md
+++ b/edifice/install_ubuntu_src.md
@@ -1,6 +1,6 @@
 # Source Installation on Ubuntu
 
-These instructions apply to Ubuntu Bionic or Focal.
+These instructions apply to Ubuntu Bionic (18.04) and Focal (20.04).
 
 ## Install tools
 
@@ -18,6 +18,14 @@ Some tools require Python 3.5 (or higher) which is not the default option on som
 platforms (like Ubuntu Focal). The Python
 [virtualenv](https://virtualenv.pypa.io/en/latest/) could be a useful solution in
 cases where the default option cannot be easily changed.
+
+## Generic tools
+
+Install tools needed by this tutorial:
+
+```bash
+sudo apt install python3-pip wget lsb-release
+```
 
 ## vcstool and colcon from pip
 
@@ -99,9 +107,8 @@ sudo apt-get update
 The command below will install all dependencies in Ubuntu Bionic or Focal:
 
 ```bash
-SYSTEM_VERSION=`lsb_release -cs`
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements
@@ -217,35 +224,4 @@ the results you want:
 
 ## Troubleshooting
 
-### Unable to create the rendering window
-
-If you're getting errors like "Unable to create the rendering window", it could
-mean you're using an old OpenGL version. Ignition Gazebo uses the Ogre 2
-rendering engine by default, which requires an OpenGL version higher than 3.3.
-
-This can be confirmed by checking the Ogre 2 logs at `~/.ignition/rendering/ogre2.log`,
-which should have an error like:
-
-"OGRE EXCEPTION(3:RenderingAPIException): OpenGL 3.3 is not supported. Please update your graphics card drivers."
-
-You can also check your OpenGL version running:
-
-    glxinfo | grep "OpenGL version"
-
-You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
-
-    ign gazebo -v 3 lights.sdf
-
-If that loads, you can continue to use Ignition with Ogre 1, just be sure to
-specify `ogre` in your SDF files instead of `ogre2`.
-
-To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
-As suggested on the Ogre logs, this may require updating your graphics card
-drivers.
-
-The Ogre 2 debs from the osrfoundation repository are built from a fork of
-Ogre's `v2-1` branch with changes needed for deb packaging and allowing it to
-be co-installable with Ogre 1.x. The code can be found here:
-
-https://github.com/osrf/ogre-2.1-release
+See [Troubleshooting](troubleshooting)

--- a/edifice/troubleshooting.md
+++ b/edifice/troubleshooting.md
@@ -1,0 +1,91 @@
+# Troubleshooting
+
+## MacOS
+
+### Unable to find `urdf_model.h` error
+
+After installing all the dependencies and starting the build process, you may encounter an error that looks like this:
+
+```bash
+/Users/user/dome_ws/src/sdformat/src/parser_urdf.cc:30:10: fatal error: 'urdf_model/model.h' file not found
+#include <urdf_model/model.h>
+         ^~~~~~~~~~~~~~~~~~~~
+1 error generated.
+make[2]: *** [src/CMakeFiles/sdformat9.dir/parser_urdf.cc.o] Error 1
+make[1]: *** [src/CMakeFiles/sdformat9.dir/all] Error 2
+make: *** [all] Error 2
+Failed   <<< sdformat9	[ Exited with code 2 ]
+```
+
+First check if `urdfdom` and `urdfdom_headers` are installed by running:
+
+```bash
+brew install urdfdom urdfdom_headers
+```
+
+Then if the error persists, compile with the internal version of `urdfdom` by running:
+
+```bash
+colcon build --cmake-args -DUSE_INTERNAL_URDF=ON --merge-install
+```
+
+This command will ignore the system installation of `urdfdom` and use the internal version instead.
+
+### Unable to load .dylib file
+
+When running the `ign gazebo -s` command, an error like the one below may show up:
+
+```bash
+Error while loading the library [/Users/dome/dome_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib]: dlopen(/Users/dome/dome_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib, 5): Library not loaded: @rpath/libIrrXML.dylib
+  Referenced from: /usr/local/opt/assimp/lib/libassimp.5.dylib
+  Reason: image not found
+[Err] [Physics.cc:275] Unable to load the /Users/dome/dome_ws/install/lib//libignition-physics2-dartsim-plugin.2.dylib library.
+Escalating to SIGKILL on [Ignition Gazebo Server]
+```
+
+The issue is related to OSX System Integrity Protection(SIP). The workaround is to run `ign` with a different ruby then make sure that ruby is loaded.
+
+```bash
+brew install ruby
+
+# Add the following to ~/.bashrc
+export PATH=/usr/local/Cellar/ruby/2.6.5/bin:$PATH
+
+# Source ~/.bashrc in terminal
+. ~/.bashrc
+```
+
+## Ubuntu
+
+### Unable to create the rendering window
+
+If you're getting errors like "Unable to create the rendering window", it could
+mean you're using an old OpenGL version. Ignition Gazebo uses the Ogre 2
+rendering engine by default, which requires an OpenGL version higher than 3.3.
+
+This can be confirmed by checking the Ogre 2 logs at `~/.ignition/rendering/ogre2.log`,
+which should have an error like:
+
+"OGRE EXCEPTION(3:RenderingAPIException): OpenGL 3.3 is not supported. Please update your graphics card drivers."
+
+You can also check your OpenGL version running:
+
+    glxinfo | grep "OpenGL version"
+
+You should be able to use Ogre 1 without any issues however. You can check if
+that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+
+    ign gazebo -v 3 lights.sdf
+
+If that loads, you can continue to use Ignition with Ogre 1, just be sure to
+specify `ogre` in your SDF files instead of `ogre2`.
+
+To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
+As suggested on the Ogre logs, this may require updating your graphics card
+drivers.
+
+The Ogre 2 debs from the osrfoundation repository are built from a fork of
+Ogre's `v2-1` branch with changes needed for deb packaging and allowing it to
+be co-installable with Ogre 1.x. The code can be found here:
+
+https://github.com/osrf/ogre-2.1-release

--- a/edifice/troubleshooting.md
+++ b/edifice/troubleshooting.md
@@ -77,8 +77,8 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 
     ign gazebo -v 3 lights.sdf
 
-If that loads, you can continue to use Ignition with Ogre 1, just be sure to
-specify `ogre` in your SDF files instead of `ogre2`.
+If that loads, you can continue to use Ignition with Ogre 1, just use the
+`--render-engine ogre` option.
 
 To enable Ogre 2 support, you'll need to update your computer's OpenGL version.
 As suggested on the Ogre logs, this may require updating your graphics card


### PR DESCRIPTION
I was setting up a new machine and noticed some places that could use improvements.

* made Citadel, Dome and Edifice installation consistent
* removed Ignition and SDF libraries from the ones installed from `packages.apt` (fixes https://github.com/ignitionrobotics/docs/issues/119)
* Added some generic tools up top which are needed for the tutorial to work on a fresh install