### PR TITLE
Use pre-release repos with nightlies

### DIFF
--- a/edifice/install_ubuntu.md
+++ b/edifice/install_ubuntu.md
@@ -6,6 +6,7 @@ the metapackage `ignition-edifice` can be installed:
 
 ```bash
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update


### PR DESCRIPTION
That's necessary because our nightlies are built against the pre-release repo.