### PR TITLE
Fix sort command in Ubuntu installation from source

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -105,7 +105,7 @@ The command below will install all dependencies in Ubuntu:
 
 ```bash
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements

--- a/dome/install_ubuntu_src.md
+++ b/dome/install_ubuntu_src.md
@@ -108,7 +108,7 @@ The command below will install all dependencies in Ubuntu Bionic or Focal:
 
 ```bash
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements

--- a/edifice/install_ubuntu_src.md
+++ b/edifice/install_ubuntu_src.md
@@ -108,7 +108,7 @@ The command below will install all dependencies in Ubuntu Bionic or Focal:
 
 ```bash
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | sed '/ignition\|sdf/d' | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```
 
 ### Install compiler requirements

--- a/tools/scripts/build_ign.sh
+++ b/tools/scripts/build_ign.sh
@@ -16,7 +16,7 @@ git clone https://github.com/$1/$2 -b $3
 cd $2
 
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
 
 mkdir build
 cd build


### PR DESCRIPTION
Exclude `.git` from the search of dependency packages to install, as previously done in https://github.com/ignition-tooling/release-tools/pull/323