### PR TITLE
Add release dates for Ignition G and H

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -20,3 +20,5 @@ An Ignition release follows the form "Ignition Codename", for example Ignition A
 | Dome       | Sep, 2020 | Dec, 2021 |       |
 | Edifice    | Mar, 2021 | Mar, 2022 |       |
 | Ignition-F | Sep, 2021 | Sep, 2026 | LTS   |
+| Ignition-G | Sep, 2022 | Sep, 2024 |       |
+| Ignition-H | Sep, 2023 | Sep, 2028 | LTS   |


### PR DESCRIPTION
As Ignition becomes a mature project, we're slowing down the release cadence after Ignition-F.  The dates loosely track Ubuntu's release schedule, so that we're about 6 months ahead of their `.04` releases.