### PR TITLE
Fix ref links in contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -10,26 +10,26 @@ propose changes to this document in a pull request.
 
 #### Table of Contents
 
-[Code of Conduct](#code-of-conduct)
+[Code of Conduct](https://ignitionrobotics.org/docs/all/contributing#code-of-conduct)
 
-[Project Design](#project-design)
+[Project Design](https://ignitionrobotics.org/docs/all/contributing#project-design)
 
-  * [Repository List](#repository-list)
+  * [Repository List](https://ignitionrobotics.org/docs/all/contributing#repository-list)
 
-[How to Contribute](#how-to-contribute)
+[How to Contribute](https://ignitionrobotics.org/docs/all/contributing#how-to-contribute)
 
-  * [Reporting Bugs](#reporting-bugs)
-  * [Suggesting Enhancements](#suggesting-enhancements)
-  * [Contributing Code](#contributing-code)
-  * [Tracking Progress](#tracking-progress)
+  * [Reporting Bugs](https://ignitionrobotics.org/docs/all/contributing#reporting-bugs)
+  * [Suggesting Enhancements](https://ignitionrobotics.org/docs/all/contributing#suggesting-enhancements)
+  * [Contributing Code](https://ignitionrobotics.org/docs/all/contributing#contributing-code)
+  * [Tracking Progress](https://ignitionrobotics.org/docs/all/contributing#tracking-progress)
 
-[Writing Tests](#writing-tests)
+[Writing Tests](https://ignitionrobotics.org/docs/all/contributing#writing-tests)
 
-  * [Test Coverage](#test-coverage)
+  * [Test Coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage)
 
-[Styleguides](#style-guides)
+[Styleguides](https://ignitionrobotics.org/docs/all/contributing#style-guides)
 
-[Appendix](#appendix)
+[Appendix](https://ignitionrobotics.org/docs/all/contributing#appendix)
 
 ## Code of Conduct
 
@@ -86,7 +86,7 @@ High performance inter- and intra-process communication based on
 **Before Submitting a Bug Report**
 
 1. Check the [questions and answers forum](http://answers.gazebosim.org). Your issue may have already been resolved.
-2. Determine [the repository](#repository-list) which should receive the problem.
+2. Determine [the repository](https://ignitionrobotics.org/docs/all/contributing#repository-list) which should receive the problem.
 3. Search the repository's issues to see if the same or similar problem has
    been opened. If it has and the issue is still open, then add a comment to
    the existing issue. Otherwise, create a new issue.
@@ -103,7 +103,7 @@ Guide](http://sscce.org/) as well as the following tips:
 * **Provide specific examples to demonstrate the steps.** Include links to files or projects, or copy/pasteable snippets, which you use in those examples.
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why**.
-* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. See [Creating GIFs](#creating-gifs) for GIF creation utilities.
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. See [Creating GIFs](https://ignitionrobotics.org/docs/all/contributing#creating-gifs) for GIF creation utilities.
 * **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
@@ -127,10 +127,10 @@ functionality. Following these guidelines helps maintainers and the
 community understand your suggestion and find related suggestions.
 
 Before creating enhancement suggestions, please check [this
-list](#before-submitting-an-enhancement-suggestion) as you
+list](https://ignitionrobotics.org/docs/all/contributing#before-submitting-an-enhancement-suggestion) as you
 might find out that you don't need to create one. When you are creating an
 enhancement suggestion, please [include as many details as
-possible](#how-do-i-submit-a-good-enhancement-suggestion).
+possible](https://ignitionrobotics.org/docs/all/contributing#how-do-i-submit-a-good-enhancement-suggestion-).
 When filling in the issue form for an enhancement suggestion, include the
 steps that you imagine you would take if the feature you're requesting
 existed.
@@ -139,7 +139,7 @@ existed.
 
 * **Check if you're using the latest software version**. A more recent version may contain your desired feature.
 * **Check if there's already [a library](https://ignitionrobotics.org/libs) which provides that enhancement.**
-* **Determine [which repository the enhancement should be suggested in](#repository-list).**
+* **Determine [which repository the enhancement should be suggested in](https://ignitionrobotics.org/docs/all/contributing#repository-list).**
 * **Perform a [cursory search](https://github.com/search?q=org%3Aignitionrobotics&type=Issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 * **Ask on the [community forum](https://community.gazebosim.org) about your
 feature.** Someone else might already have started, and you might be able to
@@ -149,7 +149,7 @@ help.
 
 Enhancement suggestions are tracked as [GitHub
 issues](https://help.github.com/en/github/managing-your-work-on-github/about-issues).
-After you've determined [which repository](#repository-list)
+After you've determined [which repository](https://ignitionrobotics.org/docs/all/contributing#repository-list)
 your enhancement suggestion is related to, create an issue on that
 repository and provide the following information:
 
@@ -157,7 +157,7 @@ repository and provide the following information:
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. See [Creating GIFs](#creating-gifs) for GIF creation utilities.
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. See [Creating GIFs](https://ignitionrobotics.org/docs/all/contributing#creating-gifs) for GIF creation utilities.
 * **Explain why this enhancement would be useful** to most users and isn't something that can or should be implemented as a separate application.
 * **Specify which version of Ignition you're using.**
 * **Specify the name and version of the OS you're using.**
@@ -168,7 +168,7 @@ We follow a development process designed to reduce errors, encourage
 collaboration, and make high quality code. Review the following to
 get acquainted with this development process.
 
-1. **Read the [Reporting Bugs](#reporting-bugs) and [Suggesting Enhancements](#suggesting-enhancements)** sections first.
+1. **Read the [Reporting Bugs](https://ignitionrobotics.org/docs/all/contributing#reporting-bugs) and [Suggesting Enhancements](https://ignitionrobotics.org/docs/all/contributing#suggesting-enhancements)** sections first.
 
 1. **Fork the Ignition library** you want to contribute to. This will create
    your own personal copy of the library. All of your development should
@@ -185,17 +185,17 @@ get acquainted with this development process.
    your life easier.
 
 1. **Write your code.** This is the fun part, but is good to remember:
-   - Always [sign your commits](https://docs.github.com/en/github/authenticating-to-github/signing-commits) (See the bullet about Developer Certificate of Origin in the [Process](#process) section below)
+   - Always [sign your commits](https://docs.github.com/en/github/authenticating-to-github/signing-commits) (See the bullet about Developer Certificate of Origin in the [Process](https://ignitionrobotics.org/docs/all/contributing#process) section below)
    - Look at the existing code and try to maintain the existing style and pattern as much as possible
    - **Always** keep your branch updated with the original repository
 
 1. **Write tests.** In most cases, a pull request will only be accepted if
-   it has tests. See the [Writing Tests](#writing-tests)
+   it has tests. See the [Writing Tests](https://ignitionrobotics.org/docs/all/contributing#writing-tests)
   section below for more information.
 
 1. **Resolve compiler warnings.** Code must have zero compile warnings, or at least make sure your pull request is not adding new warnings.
 
-1. **Follow the [style guide](#style-guides).**
+1. **Follow the [style guide](https://ignitionrobotics.org/docs/all/contributing#style-guides).**
 
     Static code checking analyzes your code for bugs, such as potential memory
     leaks, and style. Most Ignition libraries use the `cppcheck` static code
@@ -217,7 +217,7 @@ get acquainted with this development process.
 
         Built target codecheck
 
-    The tool does not catch all style errors. See the [code style](#style-guides) section below for more information.
+    The tool does not catch all style errors. See the [code style](https://ignitionrobotics.org/docs/all/contributing#style-guides) section below for more information.
 
 1. **(optional) Use clang-tidy for additional checks.**
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes broken ref links on contributing webpage.

## Summary

I just want to be able to click on things. Feel free to decline this PR if this isn't the best way to fix the links. It was minimal effort.

On the webpage, none of the internal links work https://ignitionrobotics.org/docs/all/contributing
(They only work on the GitHub page, which is the page after people click on the "edit" button on the page on the Ignition website.)

Since we're using the contributing guide more and more (including linking from the template from which this PR was created), I figure we should fix it on the website, even if that means the links on the GitHub markdown page will also link to the website?

I don't know if there's a way to make it work for both. If there is, that would be preferred.

P.S. On the page to create a PR, the template links to the contributing page on ignitionrobotics.org, but the little dialog on the right that says "Contributing guidelines" still links to the GitHub page https://github.com/ignitionrobotics/docs/blob/d56955a8ee3b19e9a1fb347c14de094a09387a8e/contributing.md
Might want to make them the same, for consistency, especially if we merge this PR.

## Checklist
- [ ] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [ ] ~~`codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))~~
- [ ] ~~All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))~~
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
