### PR TITLE
Add binary install tip

### DIFF
--- a/edifice/install_osx.md
+++ b/edifice/install_osx.md
@@ -31,3 +31,16 @@ have already installed the library from binaries, run the following command:
 ```bash
 brew uninstall ignition-edifice
 ```
+
+## Ignition libraries are not found
+
+If you see this error message:
+
+```bash
+I cannot find any available 'ign' command:
+	* Did you install any ignition library?
+	* Did you set the IGN_CONFIG_PATH environment variable?
+	    E.g.: export IGN_CONFIG_PATH=$HOME/local/share/ignition
+```
+
+You should set up the environment variable `IGN_CONFIG_PATH=/usr/local/share/ignition/`


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández <ahcorde@gmail.com>

When I installed `ignition-edifice` using `brew` the `IGN_CONFIG_PATH` environment variable is not defined. Adding a tip to solve it