### PR TITLE
Add architecture page to index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -38,7 +38,7 @@ pages:
   - name: architecture
     title: Architecture
     file: architecture.md
-    description: Getting started with Ignition.
+    description: Ignition Gazebo's architecture overview.
 releases:
   - name: edifice
     lts: false

--- a/index.yaml
+++ b/index.yaml
@@ -35,6 +35,10 @@ pages:
     title: Contributing
     file: contributing.md
     description: How to contribute to Ignition.
+  - name: architecture
+    title: Architecture
+    file: architecture.md
+    description: Getting started with Ignition.
 releases:
   - name: edifice
     lts: false


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The architecture page is not working on the site: https://ignitionrobotics.org/docs/all/architecture

This is probably not a great place to put it, but I think we'll need infrastructure updates to move it somewhere else.

## Checklist
- [x] Signed all commits for DCO
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
