### PR TITLE
Update ROS 2 Integration ros_ign_bridge link

### DIFF
--- a/citadel/ros2_integration.md
+++ b/citadel/ros2_integration.md
@@ -14,7 +14,7 @@ For this tutorial to work correctly make sure you have the following installed:
 
 * [ROS 2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/)
 * [Ignition Citadel](https://ignitionrobotics.org/docs/citadel)
-* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#building-the-bridge-from-source)
+* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/tree/ros2#from-source)
 
 ## Bidirectional communication
 

--- a/dome/ros2_integration.md
+++ b/dome/ros2_integration.md
@@ -14,7 +14,7 @@ For this tutorial to work correctly make sure you have the following installed:
 
 * [ROS 2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/)
 * [Ignition Dome](https://ignitionrobotics.org/docs/dome)
-* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#building-the-bridge-from-source)
+* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/tree/ros2#from-source)
 
 ## Bidirectional communication
 

--- a/edifice/ros2_integration.md
+++ b/edifice/ros2_integration.md
@@ -14,7 +14,7 @@ For this tutorial to work correctly make sure you have the following installed:
 
 * [ROS 2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/)
 * [Ignition Edifice](https://ignitionrobotics.org/docs/edifice)
-* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#building-the-bridge-from-source)
+* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/tree/ros2#from-source)
 
 ## Bidirectional communication
 


### PR DESCRIPTION
A very minor update to *ROS 2 Integration* page - Update link to the installation instructions for `ros_ign_bridge`.

Note: This PR is valid only if https://github.com/ignitionrobotics/ros_ign/pull/142 is merged and duplicate instructions between **README.md** and **ros_ign_bridge/README.md** are removed.

---

**Note to maintainers**: Remember to use **Squash-Merge**