### PR TITLE
Edifice pre-release available, no more nightlies

### DIFF
--- a/edifice/install_ubuntu.md
+++ b/edifice/install_ubuntu.md
@@ -19,7 +19,6 @@ Then install Ignition Edifice:
 ```bash
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install ignition-edifice


### PR DESCRIPTION
All libraries up to the `ignition-edifice` package have been pre-released for Bionic:amd64 and Focal:amd64. So there's no need to add nightlies anymore.