### PR TITLE
Add note about executable configuration for pip packages

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release
+sudo apt install python3-pip wget lsb-release gnupg
 ```
 
 ## vcstool and colcon from pip
@@ -40,6 +40,21 @@ pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensi
 ```
 
 Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
+
+After installing `vcstool` and `colcon` with PIP, you may need to add their executables to your `$PATH`.
+Check where the installation of these packages took place:
+
+```bash
+pip show vcstool || pip3 show vcstool | grep Location
+
+pip show colcon-common-extensions || pip3 show colcon-common-extensions | grep Location
+```
+
+If your install path is prefixed with `$HOME/.local`, you'll probably need to add the executables within this directory to your `$PATH` in order to avoid "command not found" errors when using `vcstool` and `colcon` later on:
+
+```bash
+export PATH=$PATH:$HOME/.local/bin/
+```
 
 ## vcstool and colcon from apt
 

--- a/dome/install_ubuntu_src.md
+++ b/dome/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release
+sudo apt install python3-pip wget lsb-release gnupg
 ```
 
 ## vcstool and colcon from pip
@@ -40,6 +40,21 @@ pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensi
 ```
 
 Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
+
+After installing `vcstool` and `colcon` with PIP, you may need to add their executables to your `$PATH`.
+Check where the installation of these packages took place:
+
+```bash
+pip show vcstool || pip3 show vcstool | grep Location
+
+pip show colcon-common-extensions || pip3 show colcon-common-extensions | grep Location
+```
+
+If your install path is prefixed with `$HOME/.local`, you'll probably need to add the executables within this directory to your `$PATH` in order to avoid "command not found" errors when using `vcstool` and `colcon` later on:
+
+```bash
+export PATH=$PATH:$HOME/.local/bin/
+```
 
 ## vcstool and colcon from apt
 

--- a/edifice/install_ubuntu_src.md
+++ b/edifice/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release
+sudo apt install python3-pip wget lsb-release gnupg
 ```
 
 ## vcstool and colcon from pip
@@ -40,6 +40,21 @@ pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensi
 ```
 
 Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
+
+After installing `vcstool` and `colcon` with PIP, you may need to add their executables to your `$PATH`.
+Check where the installation of these packages took place:
+
+```bash
+pip show vcstool || pip3 show vcstool | grep Location
+
+pip show colcon-common-extensions || pip3 show colcon-common-extensions | grep Location
+```
+
+If your install path is prefixed with `$HOME/.local`, you'll probably need to add the executables within this directory to your `$PATH` in order to avoid "command not found" errors when using `vcstool` and `colcon` later on:
+
+```bash
+export PATH=$PATH:$HOME/.local/bin/
+```
 
 ## vcstool and colcon from apt
 


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

## Summary
When following the source install instructions, users might face the error message "command not found" when trying to use `vcstool` or `colcon` if installed via PIP. I have added some information about configuring these package's executables as a part of a user's `$PATH` variable so that users can follow source install instructions using PIP instead of APT if they'd like.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**