### PR TITLE
Add parenthesis to world frame in tutorial

### DIFF
--- a/citadel/building_robot.md
+++ b/citadel/building_robot.md
@@ -163,7 +163,7 @@ Under the `</model>` tag we will add our robot model as follows:
 
 ```xml
 <model name='vehicle_blue' canonical_link='chassis'>
-    <pose relative_to=world>0 0 0 0 0 0</pose>
+    <pose relative_to='world'>0 0 0 0 0 0</pose>
 ```
 
 Here we define the name of our model `vehicle_blue`, which should be a unique name among its siblings (other tags or models on the same level).


### PR DESCRIPTION
Added parenthesis around 'world' frame in the section "defining the model". Copying and pasting the section without parenthesis results in the following Error:
"Error parsing XML in file [/home/XXX/ros2_ws/src/simulation_model/robot.sdf]: Error=XML_ERROR_PARSING_ATTRIBUTE ErrorID=8 (0x8) Line number=132: XMLElement name=pose"

The change is consistent with:
https://github.com/ignitionrobotics/docs/blob/master/citadel/tutorials/building_robot/building_robot.sdf

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Added parenthesis around 'world' frame in the section "defining the model". Copying and pasting the section without parenthesis results in the following Error:
"Error parsing XML in file [/home/XXX/ros2_ws/src/simulation_model/robot.sdf]: Error=XML_ERROR_PARSING_ATTRIBUTE ErrorID=8 (0x8) Line number=132: XMLElement name=pose"

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

