### PR TITLE
Review commit messages when merging

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -390,7 +390,8 @@ Merging strategy:
 
 * For internal contributions, give the original author some time to hit the merge button themselves / check directly with them if it’s ok to merge.
 * Default to “squash and merge”
-  * Make sure the commit message captures the core ideas of the pull request and contains all authors' signatures.
+  * Review the pull request title and reword if necessary since this will be part of the commit message.
+  * Make sure the commit message concisely captures the core ideas of the pull request and contains all authors' signatures.
 * “Rebase and merge” when moving files (do a `git mv` as a separate commit).
 * “Create a merge commit” when porting changes forward. "Rebase and merge" when porting backwards.
 * Refrain from force-pushing while the PR is under review (which includes rebasing and squashing).


### PR DESCRIPTION
This adds some guidance to the documentation about merging pull requests to recommend that the pull request title be reviewed since it will be part of the squash-merge commit message. Also add `concisely` to the squash merge commit message recommendation, since the default commit message can be very long when there are many commits.