### PR TITLE
Modernize Ubuntu repo installation in Fortress and use https

### DIFF
--- a/fortress/install_ubuntu.md
+++ b/fortress/install_ubuntu.md
@@ -17,9 +17,9 @@ Then install Ignition Fortress:
 
 
 ```bash
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-prerelease $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-prerelease.list > /dev/null
 sudo apt-get update
 sudo apt-get install ignition-fortress
 ```

--- a/fortress/install_ubuntu_src.md
+++ b/fortress/install_ubuntu_src.md
@@ -114,8 +114,8 @@ method to install software dependencies.
 Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 ```
 

--- a/tools/scripts/install_common_deps.sh
+++ b/tools/scripts/install_common_deps.sh
@@ -12,9 +12,9 @@ sudo apt-get install -y \
   lsb-release \
   wget
 
-sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-nightly $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-nightly.list > /dev/null
 
 sudo apt-get update
 


### PR DESCRIPTION
## Summary

apt-key is now deprecated and the [recommended way](https://wiki.debian.org/DebianRepository/UseThirdParty) of installing repositories is to use the `signed-by` clause in sources.list. More information in https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html.

Note that ROS2 already moved to this way of installing keys: https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html

Together with this, use httS for getting the key. The key is the same `gazebo.key` but in binary format with the name of `gazebo.gpg`.


## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)
