### PR TITLE
Updated CMakeLists to use ``ign-transport11``

### DIFF
--- a/fortress/tutorials/sensors/CMakeLists.txt
+++ b/fortress/tutorials/sensors/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 project(avoid_wall)
 
 # Find the Ignition_Transport library
-find_package(ignition-transport10 QUIET REQUIRED OPTIONAL_COMPONENTS log)
-set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
+find_package(ignition-transport11 QUIET REQUIRED OPTIONAL_COMPONENTS log)
+set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
 
 include_directories(${CMAKE_BINARY_DIR})
 


### PR DESCRIPTION
This example should use ``ign-transport11`` as discussed with @jennuine. Building this example would fail on Ubuntu 18.04 (with ignition installed from debs) otherwise