### PR TITLE
sensor_tutorial.sdf: fix bad copy/paste

### DIFF
--- a/citadel/tutorials/moving_robot/moving_robot.sdf
+++ b/citadel/tutorials/moving_robot/moving_robot.sdf
@@ -176,7 +176,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/citadel/tutorials/sensors/sensor_tutorial.sdf
+++ b/citadel/tutorials/sensors/sensor_tutorial.sdf
@@ -223,7 +223,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/dome/tutorials/moving_robot/moving_robot.sdf
+++ b/dome/tutorials/moving_robot/moving_robot.sdf
@@ -102,7 +102,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/dome/tutorials/sensors/sensor_tutorial.sdf
+++ b/dome/tutorials/sensors/sensor_tutorial.sdf
@@ -223,7 +223,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/edifice/tutorials/moving_robot/moving_robot.sdf
+++ b/edifice/tutorials/moving_robot/moving_robot.sdf
@@ -102,7 +102,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/edifice/tutorials/sensors/sensor_tutorial.sdf
+++ b/edifice/tutorials/sensors/sensor_tutorial.sdf
@@ -223,7 +223,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/fortress/tutorials/moving_robot/moving_robot.sdf
+++ b/fortress/tutorials/moving_robot/moving_robot.sdf
@@ -102,7 +102,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>

--- a/fortress/tutorials/sensors/sensor_tutorial.sdf
+++ b/fortress/tutorials/sensors/sensor_tutorial.sdf
@@ -223,7 +223,7 @@
                 <inertial>
                     <mass>2</mass>
                     <inertia>
-                     [Build your own robot](SDF_tutorial_link) tutorial. You can download the robot fro   <ixx>0.145833</ixx>
+                        <ixx>0.145833</ixx>
                         <ixy>0</ixy>
                         <ixz>0</ixz>
                         <iyy>0.145833</iyy>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of #202 

## Summary

There is some invalid xml in several tutorial `.sdf` files, probably from an errant copy-paste. This removes the errant string.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
