### PR TITLE
Add documentation about actor trajectory tension

### DIFF
--- a/edifice/actors.md
+++ b/edifice/actors.md
@@ -91,7 +91,7 @@ Inside the `<script>` tag the following parameters are available:
 Let's define the trajectory as a sequence of waypoints:
 
 ```xml
-        <trajectory id="0" type="walk">
+        <trajectory id="0" type="walk" tension="0.6">
             <waypoint>
                 <time>0</time>
                 <pose>0 0 1.0 0 0 0</pose>
@@ -132,7 +132,9 @@ Let's define the trajectory as a sequence of waypoints:
     </script>
 ```
 
-Within the `<trajectory>` tag we define a series of waypoints which our actor will follow. The `<trajectory>` has two attributes: `id` and `type`. The `type` should have the same name as the animation `walk`. Under the `trajectory` tag we define the following:
+Within the `<trajectory>` tag we define a series of waypoints which our actor will follow. The `<trajectory>` has three attributes: `id`, `type`, and `tension`. The `type` should have the same name as the animation `walk`. The `tension` parameter is used to control how closely the trajectory will stick to the given waypoints. The default `tension` value is zero, which equates to a Catmull-Rom spline, which may cause the animation to overshoot waypoints. A `tension` value of one will cause the animation to stick to the waypoints. The `tension` value should be in the range 0 to 1.
+
+Under the `trajectory` tag we define the following:
 
 * `waypoint`: There can be any number of waypoints in a trajectory. Each waypoint consists of a time and a pose:
     * `time`: The time in seconds, counted from the beginning of the script, when the pose should be reached.

--- a/fortress/actors.md
+++ b/fortress/actors.md
@@ -91,7 +91,7 @@ Inside the `<script>` tag the following parameters are available:
 Let's define the trajectory as a sequence of waypoints:
 
 ```xml
-        <trajectory id="0" type="walk">
+        <trajectory id="0" type="walk" tension="0.6">
             <waypoint>
                 <time>0</time>
                 <pose>0 0 1.0 0 0 0</pose>
@@ -132,7 +132,9 @@ Let's define the trajectory as a sequence of waypoints:
     </script>
 ```
 
-Within the `<trajectory>` tag we define a series of waypoints which our actor will follow. The `<trajectory>` has two attributes: `id` and `type`. The `type` should have the same name as the animation `walk`. Under the `trajectory` tag we define the following:
+Within the `<trajectory>` tag we define a series of waypoints which our actor will follow. The `<trajectory>` has three attributes: `id`, `type`, and `tension`. The `type` should have the same name as the animation `walk`. The `tension` parameter is used to control how closely the trajectory will stick to the given waypoints. The default `tension` value is zero, which equates to a Catmull-Rom spline, which may cause the animation to overshoot waypoints. A `tension` value of one will cause the animation to stick to the waypoints. The `tension` value should be in the range 0 to 1.
+
+Under the `trajectory` tag we define the following:
 
 * `waypoint`: There can be any number of waypoints in a trajectory. Each waypoint consists of a time and a pose:
     * `time`: The time in seconds, counted from the beginning of the script, when the pose should be reached.


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Add documentation about the tension parameter for Actor trajectories.

See also: https://github.com/ignitionrobotics/ign-common/pull/256

## Test it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**