### PR TITLE
Update branches to upload Fortress docs

### DIFF
--- a/tools/Dockerfile.fortress
+++ b/tools/Dockerfile.fortress
@@ -52,38 +52,38 @@ RUN scripts/build_ign.sh ignitionrobotics ign-common ign-common4 y \
 #       $IGN_VERSION_DATE \
 #       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-msgs main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-msgs ign-msgs8 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-transport main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-transport ign-transport11 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-fuel-tools main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-fuel-tools ign-fuel-tools7 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-rendering main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-rendering ign-rendering6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-sensors main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-sensors ign-sensors6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-gui main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-gui ign-gui6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-physics main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-physics ign-physics5 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-gazebo main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-gazebo ign-gazebo6 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0
 
-RUN scripts/build_ign.sh ignitionrobotics ign-launch main y \
+RUN scripts/build_ign.sh ignitionrobotics ign-launch ign-launch5 y \
       $IGN_VERSION_DATE \
       $IGN_VERSION_PASSWORD; exit 0


### PR DESCRIPTION
I should have done this as part of #212, but missed it. Now we have tutorials uploaded for the current `main` branches, which we shouldn't have :woman_facepalming: I'll look into cleaning that up.