### PR TITLE
Document platform support tiers for all collections

### DIFF
--- a/citadel/install.md
+++ b/citadel/install.md
@@ -50,18 +50,8 @@ These are the **officially** supported platforms:
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at **best-effort**.
-
-Operating System | Architecture | Packaging | CI | Functionality
----------------- | ------------ | --------- | -- | -------------
-Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | i386         | ✅ Yes    | No | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+Platforms supported at **best-effort** include arm architectures, Windows and
+macOS. See
+[this ticket](https://github.com/ignition-tooling/release-tools/issues/595)
+for the full status.
 

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -45,48 +45,27 @@ collection assures that all libraries are compatible and can be used together.
 
 Citadel is [supported](/docs/all/releases) on the platforms below.
 
-### Official support
+These are the officially supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-### Best-effort support
+All other platforms on the table are supported at best-effort.
 
-* Ubuntu Bionic on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Focal on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Bionic on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Ubuntu Focal on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Debian Buster on amd64, i386, arm64 and armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* MacOS Mojave
-    * Binary packages may be available
-    * Tested on CI
-    * Ignition only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
-* Windows 10
-    * Binary packages may be available
-    * Some libraries tested on CI
-    * Ignition command line utilities are not supported.
-    * All packages up to but not including `ign-gazebo` are currently building.
-    * DART physics engine is not supported.
-    * Qt (GUI functionality) is not supported.
+
+Operating System | Architecture | Packaging | CI | Functionality
+---------------- | ------------ | --------- | -- | -------------
+Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | i386         | ✅ Yes    | No | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
+MacOS Mojave     | -            | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Ignition command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+
+
+
+

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -72,6 +72,11 @@ Citadel is [supported](/docs/all/releases) on the platforms below.
     * Not tested on CI
     * Most low-level libraries known to work
     * DART physics engine not available
+* Debian Buster on amd64, i386, arm64 and armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
 * MacOS Mojave
     * Binary packages may be available
     * Tested on CI

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -62,6 +62,6 @@ Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅
 .                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
 .                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
 Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Mojave     | -            | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
 Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
 

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -45,12 +45,12 @@ collection assures that all libraries are compatible and can be used together.
 
 Citadel is [supported](/docs/all/releases) on the platforms below.
 
-These are the officially supported platforms:
+These are the **officially** supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at best-effort.
+All other platforms on the table are supported at **best-effort**.
 
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -1,18 +1,6 @@
-# Citadel Installation
+# Ignition Citadel
 
-Citadel supports the following platforms:
-
- * Ubuntu Bionic on amd64/i386 and Focal on amd64
- * MacOS Mojave
-     * Ignition currently only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
- * Windows 10
-     * Ignition command line utilities are not yet supported.
-     * All packages up to but not including `ign-gazebo` are currently building.
-     * DART physics engine is not yet supported.
-     * Qt (GUI functionality) is not yet supported.
-
+Ignition Citadel is the 3rd major release of Ignition, and its 1st 5-year-LTS.
 
 ## Binary installation instructions
 
@@ -52,3 +40,48 @@ collection assures that all libraries are compatible and can be used together.
 |   ign-tools        |       1.x     |
 |   ign-transport    |       8.x     |
 |   sdformat         |       9.x     |
+
+## Supported platforms
+
+Citadel is [supported](/docs/all/releases) on the platforms below.
+
+### Official support
+
+* Ubuntu Bionic on amd64/i386
+* Ubuntu Focal on amd64
+
+### Best-effort support
+
+* Ubuntu Bionic on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Focal on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Bionic on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* Ubuntu Focal on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* MacOS Mojave
+    * Binary packages may be available
+    * Tested on CI
+    * Ignition only works in headless mode
+      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
+      `ign gazebo -s fuel.sdf` to start the server only).
+* Windows 10
+    * Binary packages may be available
+    * Some libraries tested on CI
+    * Ignition command line utilities are not supported.
+    * All packages up to but not including `ign-gazebo` are currently building.
+    * DART physics engine is not supported.
+    * Qt (GUI functionality) is not supported.

--- a/citadel/install.md
+++ b/citadel/install.md
@@ -52,7 +52,6 @@ These are the officially supported platforms:
 
 All other platforms on the table are supported at best-effort.
 
-
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------
 Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
@@ -64,8 +63,5 @@ Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅
 .                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
 Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
 MacOS Mojave     | -            | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Ignition command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
-
-
-
+Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
 

--- a/dome/install.md
+++ b/dome/install.md
@@ -50,18 +50,7 @@ These are the **officially** supported platforms:
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at **best-effort**.
-
-Operating System | Architecture | Packaging | CI | Functionality
----------------- | ------------ | --------- | -- | -------------
-Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | i386         | ✅ Yes    | No | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
-
+Platforms supported at **best-effort** include arm architectures, Windows and
+macOS. See
+[this ticket](https://github.com/ignition-tooling/release-tools/issues/297)
+for the full status.

--- a/dome/install.md
+++ b/dome/install.md
@@ -45,48 +45,23 @@ collection assures that all libraries are compatible and can be used together.
 
 Dome is [supported](/docs/all/releases) on the platforms below.
 
-### Official support
+These are the officially supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-### Best-effort support
+All other platforms on the table are supported at best-effort.
 
-* Ubuntu Bionic on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Focal on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Bionic on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Ubuntu Focal on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Debian Buster on amd64, i386, arm64 and armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* MacOS Mojave and Catalina
-    * Binary packages may be available
-    * Tested on CI (TODO which version exactly?)
-    * Ignition only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
-* Windows 10
-    * Binary packages may be available
-    * Some libraries tested on CI
-    * Ignition command line utilities are not supported.
-    * All packages up to but not including `ign-gazebo` are currently building.
-    * DART physics engine is not supported.
-    * Qt (GUI functionality) is not supported.
+Operating System | Architecture | Packaging | CI | Functionality
+---------------- | ------------ | --------- | -- | -------------
+Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | i386         | ✅ Yes    | No | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
+MacOS Mojave and Catalina | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+

--- a/dome/install.md
+++ b/dome/install.md
@@ -45,12 +45,12 @@ collection assures that all libraries are compatible and can be used together.
 
 Dome is [supported](/docs/all/releases) on the platforms below.
 
-These are the officially supported platforms:
+These are the **officially** supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at best-effort.
+All other platforms on the table are supported at **best-effort**.
 
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------

--- a/dome/install.md
+++ b/dome/install.md
@@ -62,6 +62,6 @@ Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅
 .                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
 .                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
 Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Mojave and Catalina | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
 Windows 10       | .            | ❓ Maybe  | Some libraries tested on every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
 

--- a/dome/install.md
+++ b/dome/install.md
@@ -72,6 +72,11 @@ Dome is [supported](/docs/all/releases) on the platforms below.
     * Not tested on CI
     * Most low-level libraries known to work
     * DART physics engine not available
+* Debian Buster on amd64, i386, arm64 and armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
 * MacOS Mojave and Catalina
     * Binary packages may be available
     * Tested on CI (TODO which version exactly?)

--- a/dome/install.md
+++ b/dome/install.md
@@ -1,18 +1,6 @@
-# Dome Installation
+# Ignition Dome
 
-Dome supports the following platforms:
-
- * Ubuntu Bionic amd64/arm64/i386 and Focal on amd64/arm64
- * MacOS Mojave and Catalina
-     * Ignition currently only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
- * Windows 10
-     * Ignition command line utilities are not yet supported.
-     * All packages up to but not including `ign-gazebo` are currently building.
-     * DART physics engine is not yet supported.
-     * Qt (GUI functionality) is not yet supported.
-
+Ignition Dome is the 4th major release of Ignition. It's a short-term support.
 
 ## Binary installation instructions
 
@@ -52,3 +40,48 @@ collection assures that all libraries are compatible and can be used together.
 |   ign-tools        |       1.x     |
 |   ign-transport    |       9.x     |
 |   sdformat         |      10.x     |
+
+## Supported platforms
+
+Dome is [supported](/docs/all/releases) on the platforms below.
+
+### Official support
+
+* Ubuntu Bionic on amd64/i386
+* Ubuntu Focal on amd64
+
+### Best-effort support
+
+* Ubuntu Bionic on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Focal on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Bionic on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* Ubuntu Focal on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* MacOS Mojave and Catalina
+    * Binary packages may be available
+    * Tested on CI (TODO which version exactly?)
+    * Ignition only works in headless mode
+      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
+      `ign gazebo -s fuel.sdf` to start the server only).
+* Windows 10
+    * Binary packages may be available
+    * Some libraries tested on CI
+    * Ignition command line utilities are not supported.
+    * All packages up to but not including `ign-gazebo` are currently building.
+    * DART physics engine is not supported.
+    * Qt (GUI functionality) is not supported.

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -63,6 +63,6 @@ Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅
 .                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
 .                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
 Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Mojave and Catalina | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
 Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
 

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -1,18 +1,6 @@
-# Edifice Installation
+# Ignition Dome
 
-Edifice supports the following platforms:
-
- * Ubuntu Bionic amd64/arm64/i386 and Focal on amd64/arm64
- * MacOS Mojave and Catalina
-     * Ignition currently only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
- * Windows 10
-     * Ignition command line utilities are not yet supported.
-     * All packages up to but not including `ign-gazebo` are currently building.
-     * DART physics engine is not yet supported.
-     * Qt (GUI functionality) is not yet supported.
-
+Ignition Dome is the 5th major release of Ignition. It's a short-term support.
 
 ## Binary installation instructions
 
@@ -53,3 +41,48 @@ collection assures that all libraries are compatible and can be used together.
 |   ign-transport    |      10.x     |
 |   ign-utils        |       1.x     |
 |   sdformat         |      11.x     |
+
+## Supported platforms
+
+Edifice is [supported](/docs/all/releases) on the platforms below.
+
+### Official support
+
+* Ubuntu Bionic on amd64/i386
+* Ubuntu Focal on amd64
+
+### Best-effort support
+
+* Ubuntu Bionic on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Focal on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Bionic on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* Ubuntu Focal on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* MacOS Mojave and Catalina
+    * Binary packages may be available
+    * Tested on CI (TODO which version exactly?)
+    * Ignition only works in headless mode
+      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
+      `ign gazebo -s fuel.sdf` to start the server only).
+* Windows 10
+    * Binary packages may be available
+    * Tested on CI
+    * Ignition command line utilities are not supported.
+    * All packages up to but not including `ign-gazebo` are currently building.
+    * DART physics engine is not supported.
+    * Qt (GUI functionality) is not supported.

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -46,12 +46,12 @@ collection assures that all libraries are compatible and can be used together.
 
 Edifice is [supported](/docs/all/releases) on the platforms below.
 
-These are the officially supported platforms:
+These are the **officially** supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at best-effort.
+All other platforms on the table are supported at **best-effort**.
 
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -73,6 +73,11 @@ Edifice is [supported](/docs/all/releases) on the platforms below.
     * Not tested on CI
     * Most low-level libraries known to work
     * DART physics engine not available
+* Debian Buster on amd64, i386, arm64 and armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
 * MacOS Mojave and Catalina
     * Binary packages may be available
     * Tested on CI (TODO which version exactly?)

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -1,6 +1,6 @@
-# Ignition Dome
+# Ignition Edifice
 
-Ignition Dome is the 5th major release of Ignition. It's a short-term support.
+Ignition Edifice is the 5th major release of Ignition. It's a short-term support.
 
 ## Binary installation instructions
 
@@ -46,48 +46,23 @@ collection assures that all libraries are compatible and can be used together.
 
 Edifice is [supported](/docs/all/releases) on the platforms below.
 
-### Official support
+These are the officially supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-### Best-effort support
+All other platforms on the table are supported at best-effort.
 
-* Ubuntu Bionic on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Focal on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Bionic on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Ubuntu Focal on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Debian Buster on amd64, i386, arm64 and armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* MacOS Mojave and Catalina
-    * Binary packages may be available
-    * Tested on CI (TODO which version exactly?)
-    * Ignition only works in headless mode
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
-* Windows 10
-    * Binary packages may be available
-    * Tested on CI
-    * Ignition command line utilities are not supported.
-    * All packages up to but not including `ign-gazebo` are currently building.
-    * DART physics engine is not supported.
-    * Qt (GUI functionality) is not supported.
+Operating System | Architecture | Packaging | CI | Functionality
+---------------- | ------------ | --------- | -- | -------------
+Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | i386         | ✅ Yes    | No | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
+MacOS Mojave and Catalina | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+

--- a/edifice/install.md
+++ b/edifice/install.md
@@ -51,18 +51,7 @@ These are the **officially** supported platforms:
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 
-All other platforms on the table are supported at **best-effort**.
-
-Operating System | Architecture | Packaging | CI | Functionality
----------------- | ------------ | --------- | -- | -------------
-Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | i386         | ✅ Yes    | No | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
-
+Platforms supported at **best-effort** include arm architectures, Windows and
+macOS. See
+[this ticket](https://github.com/ignition-tooling/release-tools/issues/421)
+for the full status.

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -53,49 +53,25 @@ collection assures that all libraries are compatible and can be used together.
 
 Fortress is [supported](/docs/all/releases) on the platforms below.
 
-### Official support
+These are the officially supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 * (Ubuntu Jammy on amd64 once that's released)
 
-### Best-effort support
+All other platforms on the table are supported at best-effort.
 
-* Ubuntu Bionic on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Focal on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Bionic on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Ubuntu Focal on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Debian Buster on amd64, i386, arm64 and armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* MacOS Catalina and BigSur
-    * Binary packages may be available
-    * Tested on CI (TODO which version exactly?)
-    * Ignition only works in headless mode using Ogre 1.
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
-* Windows 10
-    * Binary packages may be available
-    * Tested on CI
-    * Ignition command line utilities are not supported.
-    * All packages up to but not including `ign-gazebo` are currently building.
-    * DART physics engine is not supported.
-    * Qt (GUI functionality) is not supported.
+Operating System | Architecture | Packaging | CI | Functionality
+---------------- | ------------ | --------- | -- | -------------
+Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | i386         | ✅ Yes    | No | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Jammy     | amd64, i386, arm64, armhf | TODO    | TODO | TODO
+Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
+MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode using Ogre 1 (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -80,6 +80,11 @@ Fortress is [supported](/docs/all/releases) on the platforms below.
     * Not tested on CI
     * Most low-level libraries known to work
     * DART physics engine not available
+* Debian Buster on amd64, i386, arm64 and armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
 * MacOS Catalina and BigSur
     * Binary packages may be available
     * Tested on CI (TODO which version exactly?)

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -53,13 +53,13 @@ collection assures that all libraries are compatible and can be used together.
 
 Fortress is [supported](/docs/all/releases) on the platforms below.
 
-These are the officially supported platforms:
+These are the **officially** supported platforms:
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
 * (Ubuntu Jammy on amd64 once that's released)
 
-All other platforms on the table are supported at best-effort.
+All other platforms on the table are supported at **best-effort**.
 
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -59,19 +59,7 @@ These are the **officially** supported platforms:
 * Ubuntu Focal on amd64
 * (Ubuntu Jammy on amd64 once that's released)
 
-All other platforms on the table are supported at **best-effort**.
-
-Operating System | Architecture | Packaging | CI | Functionality
----------------- | ------------ | --------- | -- | -------------
-Ubuntu Bionic    | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | i386         | ✅ Yes    | No | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Jammy     | amd64, i386, arm64, armhf | TODO    | TODO | TODO
-Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode using Ogre 1 (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
-
+Platforms supported at **best-effort** include arm architectures, Windows and
+macOS. See
+[this ticket](https://github.com/ignition-tooling/release-tools/issues/596)
+for the full status.

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -57,6 +57,7 @@ Fortress is [supported](/docs/all/releases) on the platforms below.
 
 * Ubuntu Bionic on amd64/i386
 * Ubuntu Focal on amd64
+* (Ubuntu Jammy on amd64 once that's released)
 
 ### Best-effort support
 

--- a/fortress/install.md
+++ b/fortress/install.md
@@ -1,17 +1,6 @@
-# Fortress Installation
+# Ignition Fortress
 
-Fortress supports the following platforms:
-
- * Ubuntu Bionic amd64/arm64/i386 and Focal on amd64/arm64
- * MacOS Catalina and BigSur
-     * Ignition currently only works in headless mode using Ogre 1
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
- * Windows 10
-     * Ignition command line utilities are not yet supported.
-     * All packages up to `ign-gazebo` can be built.
-     * DART physics engine is not yet supported.
-     * Qt (GUI functionality) is not yet supported.
+Ignition Fortress is the 6th major release of Ignition, and its 2nd 5-year LTS.
 
 ## Binary installation instructions
 
@@ -59,3 +48,48 @@ collection assures that all libraries are compatible and can be used together.
 |   ign-transport    |      11.x     |
 |   ign-utils        |       1.x     |
 |   sdformat         |      12.x     |
+
+## Supported platforms
+
+Fortress is [supported](/docs/all/releases) on the platforms below.
+
+### Official support
+
+* Ubuntu Bionic on amd64/i386
+* Ubuntu Focal on amd64
+
+### Best-effort support
+
+* Ubuntu Bionic on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Focal on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Bionic on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* Ubuntu Focal on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* MacOS Catalina and BigSur
+    * Binary packages may be available
+    * Tested on CI (TODO which version exactly?)
+    * Ignition only works in headless mode using Ogre 1.
+      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
+      `ign gazebo -s fuel.sdf` to start the server only).
+* Windows 10
+    * Binary packages may be available
+    * Tested on CI
+    * Ignition command line utilities are not supported.
+    * All packages up to but not including `ign-gazebo` are currently building.
+    * DART physics engine is not supported.
+    * Qt (GUI functionality) is not supported.

--- a/garden/install.md
+++ b/garden/install.md
@@ -1,21 +1,9 @@
-# Garden Installation
+# Garden Fortress
+
+Ignition Garden will be the 7th major release of Ignition. It will be a
+short-term release.
 
 Up to Garden's release date, the collection should be considered unstable.
-
-For the moment, Garden supports the following platforms:
-
- * Ubuntu Bionic amd64/arm64/i386 and Focal on amd64/arm64
- * MacOS Catalina and BigSur
-     * Ignition currently only works in headless mode using Ogre 1
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
- * Windows 10
-     * Ignition command line utilities are not yet supported.
-     * All packages up to `ign-gazebo` can be built.
-     * DART physics engine is not yet supported.
-     * Qt (GUI functionality) is not yet supported.
-
-The supported platforms may change up to the release date.
 
 ## Binary installation instructions
 
@@ -54,3 +42,49 @@ This list of library versions may change up to the release date.
 |   ign-transport    |      11.x     |
 |   ign-utils        |       1.x     |
 |   sdformat         |      12.x     |
+
+## Supported platforms
+
+Garden is planned to be [supported](/docs/all/releases) on the platforms below.
+This list may change up to the release date.
+
+### Official support
+
+* Ubuntu Focal on amd64
+* Ubuntu Jammy on amd64
+
+### Best-effort support
+
+* Ubuntu Bionic on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Focal on arm64
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
+* Ubuntu Bionic on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* Ubuntu Focal on armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * DART physics engine not available
+* MacOS Catalina and BigSur
+    * Binary packages may be available
+    * Tested on CI (TODO which version exactly?)
+    * Ignition only works in headless mode using Ogre 1.
+      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
+      `ign gazebo -s fuel.sdf` to start the server only).
+* Windows 10
+    * Binary packages may be available
+    * Tested on CI
+    * Ignition command line utilities are not supported.
+    * All packages up to but not including `ign-gazebo` are currently building.
+    * DART physics engine is not supported.
+    * Qt (GUI functionality) is not supported.

--- a/garden/install.md
+++ b/garden/install.md
@@ -75,6 +75,11 @@ This list may change up to the release date.
     * Not tested on CI
     * Most low-level libraries known to work
     * DART physics engine not available
+* Debian Buster on amd64, i386, arm64 and armhf
+    * Binary packages may be available
+    * Not tested on CI
+    * Most low-level libraries known to work
+    * TODO: what is know not to work?
 * MacOS Catalina and BigSur
     * Binary packages may be available
     * Tested on CI (TODO which version exactly?)

--- a/garden/install.md
+++ b/garden/install.md
@@ -48,12 +48,12 @@ This list of library versions may change up to the release date.
 Garden is planned to be [supported](/docs/all/releases) on the platforms below.
 This list may change up to the release date.
 
-These are the officially supported platforms:
+These are the **officially** supported platforms:
 
 * Ubuntu Focal on amd64
 * Ubuntu Jammy on amd64
 
-All other platforms on the table are supported at best-effort.
+All other platforms on the table are supported at **best-effort**.
 
 Operating System | Architecture | Packaging | CI | Functionality
 ---------------- | ------------ | --------- | -- | -------------

--- a/garden/install.md
+++ b/garden/install.md
@@ -53,15 +53,7 @@ These are the **officially** supported platforms:
 * Ubuntu Focal on amd64
 * Ubuntu Jammy on amd64
 
-All other platforms on the table are supported at **best-effort**.
-
-Operating System | Architecture | Packaging | CI | Functionality
----------------- | ------------ | --------- | -- | -------------
-Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
-.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
-.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
-Ubuntu Jammy     | amd64, i386, arm64, armhf | TODO    | TODO | TODO
-Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
-MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode using Ogre 1 (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
-Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
-
+Platforms supported at **best-effort** include arm architectures, Windows and
+macOS. See
+[this ticket](https://github.com/ignition-tooling/release-tools/issues/597)
+for the full status.

--- a/garden/install.md
+++ b/garden/install.md
@@ -48,48 +48,20 @@ This list of library versions may change up to the release date.
 Garden is planned to be [supported](/docs/all/releases) on the platforms below.
 This list may change up to the release date.
 
-### Official support
+These are the officially supported platforms:
 
 * Ubuntu Focal on amd64
 * Ubuntu Jammy on amd64
 
-### Best-effort support
+All other platforms on the table are supported at best-effort.
 
-* Ubuntu Bionic on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Focal on arm64
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* Ubuntu Bionic on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Ubuntu Focal on armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * DART physics engine not available
-* Debian Buster on amd64, i386, arm64 and armhf
-    * Binary packages may be available
-    * Not tested on CI
-    * Most low-level libraries known to work
-    * TODO: what is know not to work?
-* MacOS Catalina and BigSur
-    * Binary packages may be available
-    * Tested on CI (TODO which version exactly?)
-    * Ignition only works in headless mode using Ogre 1.
-      (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use
-      `ign gazebo -s fuel.sdf` to start the server only).
-* Windows 10
-    * Binary packages may be available
-    * Tested on CI
-    * Ignition command line utilities are not supported.
-    * All packages up to but not including `ign-gazebo` are currently building.
-    * DART physics engine is not supported.
-    * Qt (GUI functionality) is not supported.
+Operating System | Architecture | Packaging | CI | Functionality
+---------------- | ------------ | --------- | -- | -------------
+Ubuntu Focal     | amd64        | ✅ Yes    | ✅ Yes, every pull request | ✅ All
+.                | arm64        | ❓ Maybe  | No | Most low-level libraries known to work
+.                | armhf        | ❓ Maybe  | No | Most low-level libraries known to work, DART physics engine not available
+Ubuntu Jammy     | amd64, i386, arm64, armhf | TODO    | TODO | TODO
+Debian Buster    | amd64, i386, arm64, armhf | ❓ Maybe | No | Several libraries known to work
+MacOS Catalina and BigSur | -   | ✅ Yes    | ✅ Yes, every pull request (TODO: which version?) | Ignition only works in headless mode using Ogre 1 (GUI does not render; instead of using `ign gazebo fuel.sdf` command, use `ign gazebo -s fuel.sdf` to start the server only).
+Windows 10       | .            | ❓ Maybe  | ✅ Yes, every pull request | Command line utilities are not supported. All packages up to but not including `ign-gazebo` are currently building. DART physics engine is not supported. Qt (GUI functionality) is not supported.
+

--- a/garden/install.md
+++ b/garden/install.md
@@ -1,4 +1,4 @@
-# Garden Fortress
+# Ignition Garden
 
 Ignition Garden will be the 7th major release of Ignition. It will be a
 short-term release.

--- a/index.yaml
+++ b/index.yaml
@@ -50,11 +50,6 @@ pages:
     file: ci.md
     description: Continuous Integration overview.
     unlisted: true
-  - name: support
-    title: Support tiers
-    file: support.md
-    description: Level of support for different platforms.
-    unlisted: true
 releases:
   - name: garden
     lts: false

--- a/index.yaml
+++ b/index.yaml
@@ -43,12 +43,17 @@ pages:
   - name: release
     title: Release process
     file: release.md
-    description: Release process overview
+    description: Release process overview.
     unlisted: true
   - name: ci
     title: Continuous Integration
     file: ci.md
-    description: Continuous Integration overview
+    description: Continuous Integration overview.
+    unlisted: true
+  - name: support
+    title: Support tiers
+    file: support.md
+    description: Level of support for different platforms.
     unlisted: true
 releases:
   - name: garden

--- a/releases.md
+++ b/releases.md
@@ -86,4 +86,3 @@ In general, there are three categories of support for a platform:
   supported platform at a point in time, there are no guarantees that it will
   remain in the future.
 
-

--- a/releases.md
+++ b/releases.md
@@ -81,10 +81,14 @@ In general, there are three categories of support for a platform:
   may be present in released versions for these platforms. Known errors in
   best-effort platforms will be addressed subject to resource availability on a
   best-effort basis and may or may not be corrected prior to new releases.
-* **Not supported**: All platforms not included under official or best-effort
-  support are considered not supported. If a release is functional in a not
-  supported platform at a point in time, there are no guarantees that it will
-  remain in the future. Pull requests addressing issues on not supported
+* **No effort to support**: All platforms not included under official or
+  best-effort support are considered not supported. If a release is functional
+  in a platform that isn't supported at a point in time, there are no guarantees
+  that it will remain so in the future. Pull requests addressing issues on these
   platforms may be considered if they don't break any supported platforms and
   reviewed as time allows.
+
+If you or your company are interested in directly supporting, or
+sponsoring the support of other platforms, please contact
+`info@openrobotics.org`.
 

--- a/releases.md
+++ b/releases.md
@@ -57,3 +57,33 @@ Ign-(N+2)   | void bar();
 
 Check out [this table](https://github.com/ignitionrobotics/docs/blob/master/tools/versions.md)
 for a list of release and EOL dates for all versions of all libraries.
+
+### Supported platforms
+
+Platforms are defined as a combination of operating system and architecture.
+For example, "Ubuntu Focal on amd64".
+
+Each release is targeted at a specific set of platforms. A support level applies
+to an entire Ignition release, including all library versions within it. The
+supported platforms for each release are listed on their home pages (i.e.
+[Fortress](https://ignitionrobotics.org/docs/fortress)).
+
+In general, there are three categories of support for a platform:
+
+* **Official support**: Officially supported platforms are regularly tested on
+  continuous integration and released as binary packages. Errors or bugs
+  discovered in these platforms are prioritized for correction by the
+  development team. Significant errors discovered in these platforms can impact
+  release dates and we strive to resolve all known high priority errors in
+  officially supported platforms prior to new version releases.
+* **Best-effort support**: Platforms supported at best-effort may be regularly
+  tested on continuous integration and / or released as binary packages. Errors
+  may be present in released versions for these platforms. Known errors in
+  best-effort platforms will be addressed subject to resource availability on a
+  best-effort basis and may or may not be corrected prior to new releases.
+* **Not supported**: All platforms not included under official or best-effort
+  support are considered not supported. If a release is functional in a not
+  supported platform at a point in time, there are no guarantees that it will
+  remain in the future.
+
+

--- a/releases.md
+++ b/releases.md
@@ -84,5 +84,7 @@ In general, there are three categories of support for a platform:
 * **Not supported**: All platforms not included under official or best-effort
   support are considered not supported. If a release is functional in a not
   supported platform at a point in time, there are no guarantees that it will
-  remain in the future.
+  remain in the future. Pull requests addressing issues on not supported
+  platforms may be considered if they don't break any supported platforms and
+  reviewed as time allows.
 


### PR DESCRIPTION
The tiers of support are inspired by [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers). I thought it was better to go with names rather than numbers because numbers are less flexible if we want to add intermediate / alternative tiers in the future. I'm open to other tier names though.

With this PR I'm just documenting the status quo for all stable distributions, and starting to iterate for Garden. The main change for Garden, so far, is dropping Bionic.

I'm still tracking down caveats for non-amd architectures, which we've been historically bad at documenting. 
