### PR TITLE
Update the function names item in the style guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -642,8 +642,8 @@ In general, we follow [Google's style guide](https://google.github.io/styleguide
 1. **Camel case**
 > In general, everything should use camel case. Exceptions include SDF element names, and protobuf variable names. Here is an [example](https://github.com/ignitionrobotics/ign-gazebo/blob/de5b025968c9cf0cfbfd8a852458482e87c70c6c/include/ignition/gazebo/SdfEntityCreator.hh#L64-L65).
 
-1. **Class function names**
-> Class functions must start with a capital letter, and capitalize every word.
+1. **Function names**
+> All functions (member functions and free functions) must start with a capital letter, and capitalize every word.
 >
 > `void MyFunction();` : Good
 >

--- a/contributing.md
+++ b/contributing.md
@@ -642,12 +642,20 @@ In general, we follow [Google's style guide](https://google.github.io/styleguide
 1. **Camel case**
 > In general, everything should use camel case. Exceptions include SDF element names, and protobuf variable names. Here is an [example](https://github.com/ignitionrobotics/ign-gazebo/blob/de5b025968c9cf0cfbfd8a852458482e87c70c6c/include/ignition/gazebo/SdfEntityCreator.hh#L64-L65).
 
-1. **Function names**
-> All functions (member functions and free functions) must start with a capital letter, and capitalize every word.
+1. **Member function names**
+> Member functions, including static member functions, must start with a capital letter, and capitalize every word.
 >
-> `void MyFunction();` : Good
+> `void MyClass::MyFunction();` : Good
 >
-> `void myFunction();` : Bad
+> `void MyClass::myFunction();` : Bad
+>
+> `void MyClass::my_function();` : Bad
+
+1. **Free function names**
+> Free functions in namespace and global scope must start with a lowercase letter, and capitalize every word thereafter.
+> `void myFunction();` : Good
+>
+> `void MyFunction();` : Bad
 >
 > `void my_function();` : Bad
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
We've had confusion as to what style to use when naming functions. The Google style guide says the following:

> Regular functions have mixed case; accessors and mutators may be named like variables.

> Ordinarily, functions should start with a capital letter and have a capital letter for each new word.

Since we require all member functions to use `CamelCase`, this implies that all functions in ignition should use `CamelCase`.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
