### PR TITLE
Changed to Foxy branch and Binaries tab

### DIFF
--- a/citadel/ros2_integration.md
+++ b/citadel/ros2_integration.md
@@ -14,7 +14,7 @@ For this tutorial to work correctly make sure you have the following installed:
 
 * [ROS 2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/)
 * [Ignition Citadel](https://ignitionrobotics.org/docs/citadel)
-* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/tree/ros2#from-source)
+* [ros_ign_bridge](https://github.com/ignitionrobotics/ros_ign/tree/foxy#binaries)
 
 ## Bidirectional communication
 


### PR DESCRIPTION
Very very minor update. 

In the [ros2 integration](https://ignitionrobotics.org/docs/citadel/ros2_integration) tutorial, it has 3 links in the "requirements" tab. The third links to ros_ign_bridge ros2 branch. 
Even though it's a tutorial for Foxy and Citadel, which should be the Foxy branch. 
It doesn't make sence for the ros_ign bridge to link to the ros2 branch (which is for ROS 2 Rolling).

Also, it made more sense to link to the binaries, since they are for Citadel and the ros2_integration page is also for Citadel.

Like I said, small change. LMK if there's something wrong.