### PR TITLE
Deduplicate files before upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,21 +81,30 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: false
+    env:
+      BUILD_DIR: merged_artifacts/
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: ${{ env.BUILD_DIR }}
+      - name: Deduplicate files
+        run: |
+          sudo apt-get install -y rdfind symlinks
+          bash tools/deduplicate_files.sh $BUILD_DIR
       - name: Upload merged
         uses: actions/upload-artifact@v4
         with:
           name: website-docs-merged
-          path: ./
+          path: ${{ env.BUILD_DIR }}
       - name: Commit
-        uses: peaceiris/actions-gh-pages@v4
         # The workflow upto this point is good for generating a preview,
         # but only commit to deploy if we are on the master branch (not a pull request).
         if: github.ref == 'refs/heads/master'
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
-          keep_files: true
+          folder: ${{ env.BUILD_DIR }}
+          clean-exclude: |
+            api/*

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -74,6 +74,10 @@ jobs:
         pattern: api-docs-*
         merge-multiple: false
     - run: python3 tools/restructure_doxygen_artifacts.py --input ${{steps.download.outputs.download-path}} .api-out
+    - name: Deduplicate files
+      run: |
+        sudo apt-get install -y rdfind symlinks
+        bash tools/deduplicate_files.sh .api-out
     - uses: actions/upload-artifact@v4
       with:
         name: api-docs
@@ -84,9 +88,8 @@ jobs:
       # The workflow upto this point is good for generating a preview,
       # but only commit to deploy if we are on the master branch (not a pull request).
       if: github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v4
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./.api-out
-        destination_dir: api
-        keep_files: true
+        folder: ./.api-out
+        target-folder: api
+        clean: false

--- a/tools/deduplicate_files.sh
+++ b/tools/deduplicate_files.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright (C) 2025 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script uses the commands rdfind and symlinks to detect duplicates and
+# replace them with symlinks leaving only one copy from the list of duplicates.
+
+if [[ $# -lt 1 ]]; then
+    echo "deduplicate_files <directory>"
+    exit 1
+fi
+
+(
+  cd ${1}
+  rdfind -makeresultsfile false -makesymlinks true .
+  symlinks -cr .
+)
+


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The deployment workflow has been emitting a warning:

```
Uploaded artifact size of 1134911337 bytes exceeds the allowed size of 1 GB. Deployment might fail.
```
(from https://github.com/gazebosim/docs/actions/runs/17334857052)

So far, deployments haven't failed despite this warning. However, to ensure they continue to work, this PR adds a deduplication step before the files are pushed to the `gh-pages` branch. This step detects duplicate files based on md5 hashes and replaces all but one of them with symlinks. I have tested it on my fork of this repo and the artifact has shrunk to 872 MB. See https://github.com/azeey/docs/actions/runs/17338291345.

Notes:
I had to change the action that's used to commit the changes from `peaceiris/actions-gh-pages@v4` to `JamesIves/github-pages-deploy-action@v4` because the previous one did not support symlinks (see https://github.com/peaceiris/actions-gh-pages/issues/643).

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.