### PR TITLE
[Jetty] Migrate Windows source installation to use Pixi

### DIFF
--- a/jetty/install_windows_src.md
+++ b/jetty/install_windows_src.md
@@ -134,9 +134,9 @@ cd gazebo
 pixi shell
 .\install\setup.ps1
 ```
-<div class="warning">
+:::{warning}
 An issue in the conda-forge Qt6 package is requiring to set QT environment variables:
-</div>
+:::
 
 ```bash
 # Until https://github.com/conda-forge/qt-main-feedstock/issues/275 is resolved


### PR DESCRIPTION
# 🎉 New feature

The PR migrates the current documentation for installing windows from sources for the Jetty distribution. Instead of using miniforge installer and conda workspaces, the PR makes the use of Pixi.

## Summary

Pixi is now being used by part of the members of the Gazebo core team and is handling the buildfarm CI. The same conda-forge packages are used but controlled by a Pixi configuration file so every time the same set of packages are installed.

The PR includes the set of QT environment variables to workaround the bug in 
https://github.com/conda-forge/qt-main-feedstock/issues/275.

Some related changes that can/needs to be merged with this PR:
 * Use of QT 6.8 for Jetty https://github.com/gazebo-tooling/release-tools/pull/1388
 * Changes from https://github.com/gazebosim/gz-sim/pull/3074

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)