### PR TITLE
Add section on lookup wheel slip in Jetty release notes

### DIFF
--- a/jetty/release_notes.md
+++ b/jetty/release_notes.md
@@ -110,7 +110,17 @@ one of the implementation pull requests
 ## Occupancy Grid Export
 
 This enhancement adds a plugin that enables end users to directly export occupancy
-grids for use with Nav2 or other mobile robotics software. 
+grids for use with Nav2 or other mobile robotics software.
 
 See the pull request <https://github.com/gazebosim/gz-sim/pull/2958> for more details.
 
+## Lookup Wheel Slip system
+
+Introduced a new system that works in conjunction with the existing `WheelSlip`
+system to dynamically adjust wheel slip and friction parameters. Using an 8-bit
+slip- and friction-encoded lookup map representing the terrain the wheeled
+vehicle is on, the `LookupWheelSlip` system modifies lateral slip, longitudinal
+slip, and friction parameters in real time based on the wheel's position in the
+world, enabling more realistic vehicle behavior on variable surfaces.
+
+See the pull request <https://github.com/gazebosim/gz-sim/pull/3003> for more details.


### PR DESCRIPTION


# 🎉 New feature

## Summary

Highlight lookup wheelslip system in release notes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
