### PR TITLE
install_windows_src: Remove description of gz sim -g workaround

### DIFF
--- a/jetty/install_windows_src.md
+++ b/jetty/install_windows_src.md
@@ -174,14 +174,6 @@ page to start using Gazebo!
 > ```
 > Remember to set the same partition in all other consoles.
 
-### Gazebo GUI workaround
-
-Although running `gz sim` without arguments is not supported on Windows,
- the `gz sim -g` command is  supported, and you can use it to launch the graphical interface on Windows.
-
-
-This should allow you to run the GUI in a separate console, connecting to the server running in another console.
-
 ## Uninstalling source-based install
 
 A source-based install can be "uninstalled" using several methods, depending on


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

From what I understand, gz sim should now working fine on Windows, so it does not make a lot of sense to have this section anymore.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

