### PR TITLE
Update install_ubuntu.md

### DIFF
--- a/ionic/install_ubuntu.md
+++ b/ionic/install_ubuntu.md
@@ -8,7 +8,7 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release gnupg
+sudo apt-get install curl lsb-release gnupg
 ```
 
 Then install Gazebo Ionic:


### PR DESCRIPTION
# Improve doc

## Summary

Add missing `curl` package in the list of necessary tools for installing Gazebo Ionic on Ubuntu.