### PR TITLE
Reverse order of releases Gantt chart

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -32,17 +32,17 @@ gantt
     axisFormat %Y
     dateFormat  YYYY-MM
                           
-    Acropolis          :acropolis, 2019-02, 2019-09
-    Blueprint          :blueprint, 2019-05, 2020-12
-    Citadel            :citadel,   2019-12, 5y
-    Dome               :dome,      2020-09, 2021-12
-    Edifice            :edifice,   2021-03, 1y
-    Fortress    :crit, :fortress,  2021-09, 5y
-    Garden             :garden,    2022-09, 2024-11
-    Harmonic    :crit, :harmonic,  2023-09, 5y
-    Ionic       :crit, :ionic,     2024-09, 2y
-    Jetty       :crit, :jetty,     2025-09, 5y
     Kura               :kura,      2026-08, 2y
+    Jetty       :crit, :jetty,     2025-09, 5y
+    Ionic       :crit, :ionic,     2024-09, 2y
+    Harmonic    :crit, :harmonic,  2023-09, 5y
+    Garden             :garden,    2022-09, 2024-11
+    Fortress    :crit, :fortress,  2021-09, 5y
+    Edifice            :edifice,   2021-03, 1y
+    Dome               :dome,      2020-09, 2021-12
+    Citadel            :citadel,   2019-12, 5y
+    Blueprint          :blueprint, 2019-05, 2020-12
+    Acropolis          :acropolis, 2019-02, 2019-09
 ~~~
 
 ## Library Versions


### PR DESCRIPTION
# 🦟 Bug fix

Not sure if it's a fix; it's a subjective change

## Summary

This reverses the order of elements in the Gantt chart to match the order of the table. The chart currently flows from upper left to lower right (which I think is typical for Gantt charts), and this changes it to flow from bottom left to upper right. It's subjective, but I think it looks more like a staircase now, like something growing, rather than descending.

Feel free to decline, but I kinda like it better this way.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
