### PR TITLE
Fix Honu Robotics main URL

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -59,14 +59,14 @@ The Gazebo PMC currently consists of the following individuals:
 
 | Name                 | Affiliation                                    | Github Handle                                   | PMC Role       | Time Zone (optional)    |
 | -------------------- | ---------------------------------------------- | ----------------------------------------------- | -------------- | ----------------------- |
-| Carlos Agüero        | [Honu Robotics](https://www.honurobotics.com/) | [caguero](https://github.com/caguero)           | Member         | CET (UTC+2)/CET (UTC+1) |
+| Carlos Agüero        | [Honu Robotics](https://honurobotics.com)      | [caguero](https://github.com/caguero)           | Member         | CET (UTC+2)/CET (UTC+1) |
 | Michael Carroll      | [Intrinsic](https://www.intrinsic.ai/)         | [mjcarroll](https://github.com/mjcarroll)       | Member         | CST (UTC-6)/CDT (UTC-5) | 
 | Ian Chen             | [Intrinsic](https://www.intrinsic.ai/)         | [iche033](https://github.com/iche033)           | Member         | PST (UTC-8)/PDT (UTC-7) |
-| Alejandro Hernández  | [Honu Robotics](https://www.honurobotics.com/) | [ahcorde](https://github.com/ahcorde)           | Member         | CET (UTC+2)/CET (UTC+1) |
+| Alejandro Hernández  | [Honu Robotics](https://honurobotics.com)      | [ahcorde](https://github.com/ahcorde)           | Member         | CET (UTC+2)/CET (UTC+1) |
 | Jenn Nguyen          | [Intrinsic](https://www.intrinsic.ai/)         | [jennuine](https://github.com/jennuine)         | Member         | PST (UTC-8)/PDT (UTC-7) |
 | Benjamin Perseghetti | [Rudis Labs](https://github.com/rudislabs)     | [bperseghetti](https://github.com/bperseghetti) | Member         | EST (UTC-5)/EDT (UTC-4) |
 | Steve Peters         | [Intrinsic](https://www.intrinsic.ai/)         | [scpeters](https://github.com/scpeters)         | Member         | PST (UTC-8)/PDT (UTC-7) |
-| Jose Luis Rivero     | [Honu Robotics](https://www.honurobotics.com/) | [jrivero](https://github.com/j-rivero)          | Member         | CET (UTC+2)/CET (UTC+1) |
+| Jose Luis Rivero     | [Honu Robotics](https://honurobotics.com)      | [jrivero](https://github.com/j-rivero)          | Member         | CET (UTC+2)/CET (UTC+1) |
 | Silvio Traversaro    | [Italian Institute of Technology](https://www.iit.it) | [traversaro](https://github.com/traversaro)  | Member     | CEST (UTC+2)/CET (UTC+1) |
 | Addisu Z. Taddese    | [Intrinsic](https://www.intrinsic.ai/)         | [azeey](https://github.com/azeey)               | Project Leader | CST (UTC-6)/CDT (UTC-5) |
 


### PR DESCRIPTION
Cosmetical fix to our company webpage references: Honu Robotics official URL is not www.honurobotics.com but https://honurobotics.com. 