### PR TITLE
Adding Ubuntu server-only instructions for Jetty

### DIFF
--- a/jetty/install.md
+++ b/jetty/install.md
@@ -11,6 +11,14 @@ Binary installation is the recommended method of installing Gazebo.
  * [Binary Installation on macOS](install_osx)
  * [Binary Installation on Windows](install_windows)
 
+## Server-only installation
+
+A server-only package is available on Ubuntu for headless and CI environments.
+It installs the Gazebo server without GUI components, avoiding Qt and extra X11
+dependencies to provide a much lighter installation.
+
+ * [Server-only Installation on Ubuntu](install_ubuntu#server-only-installation)
+
 ## Source Installation instructions
 
 Source installation is recommended for users planning on altering Gazebo's source code (advanced).

--- a/jetty/install.md
+++ b/jetty/install.md
@@ -17,7 +17,7 @@ A server-only package is available on Ubuntu for headless and CI environments.
 It installs the Gazebo server without GUI components, avoiding Qt and extra X11
 dependencies to provide a much lighter installation.
 
- * [Server-only Installation on Ubuntu](install_ubuntu#server-only-installation)
+ * [Server-only Installation on Ubuntu](install_ubuntu.md#server-only-installation)
 
 ## Source Installation instructions
 

--- a/jetty/install_ubuntu.md
+++ b/jetty/install_ubuntu.md
@@ -26,6 +26,7 @@ All libraries should be ready to use and the `gz sim` app ready to be executed.
 Head back to the [Getting started](getstarted)
 page to start using Gazebo!
 
+(server-only-installation)=
 ## Server-only installation
 
 For headless and CI environments where the GUI is not needed, the

--- a/jetty/install_ubuntu.md
+++ b/jetty/install_ubuntu.md
@@ -26,6 +26,33 @@ All libraries should be ready to use and the `gz sim` app ready to be executed.
 Head back to the [Getting started](getstarted)
 page to start using Gazebo!
 
+## Server-only installation
+
+For headless and CI environments where the GUI is not needed, the
+`gz-sim10-server` package provides a lightweight alternative. It installs only
+the Gazebo simulation server (`gz-sim-server`) without any GUI or Qt
+dependencies, resulting in a significantly smaller installation footprint.
+
+After configuring the repository (same as above), install the server-only
+package:
+
+```bash
+sudo apt-get install gz-sim10-server
+```
+
+The server-only package includes the DART physics engine and the core
+simulation server plugins. To start a headless simulation:
+
+```bash
+/usr/libexec/gz/sim10/gz-sim-server <world_file.sdf>
+```
+
+:::{note}
+The server-only binary is installed at `/usr/libexec/gz/sim10/gz-sim-server`,
+which is not in the `PATH` by default. The regular `gz sim -s` command is not
+available in the server-only installation since it requires the full
+`gz-sim10-cli` package.
+:::
 
 ## Uninstalling binary install
 


### PR DESCRIPTION
Part of https://github.com/gazebo-release/gz-sim8-release/issues/8 . Waiting to the release of gz-sim so please do not merge.