### PR TITLE
Add missing reference to ros_gz_image per #432

### DIFF
--- a/harmonic/ros2_overview.md
+++ b/harmonic/ros2_overview.md
@@ -79,3 +79,11 @@ Gazebo/ROS integration.
 * [How to use ROS 2 to interact with Gazebo](ros2_integration).
 * [Example of using ROS 2 to load a model and interact with it in Gazebo](ros2_interop).
 * [How to spawn a Gazebo model from ROS 2](ros2_spawn_model).
+---
+## Specialized Transports: Images
+
+While the standard `ros_gz_bridge` handles most ROS 2 message types, Gazebo provides a specialized package optimized specifically for heavy camera sensor data:
+
+* **[`ros_gz_image`](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_image):** Provides a unidirectional bridge for images from Gazebo to ROS 2. It utilizes `image_transport` to publish compressed and uncompressed image streams efficiently.
+
+For performance-critical simulations involving vision or cameras, using this dedicated package is heavily recommended over passing large image arrays through the standard bridge.


### PR DESCRIPTION

# 📝 Documentation Update

Addresses gazebosim/docs#432

## Summary
The ROS 2 Integration overview page was missing references to the specialized image transport packages. This PR adds a brief section highlighting `ros_gz_image` for heavy sensor data transport.

*(Note: Per @azeey's comment on the issue regarding `ros_gz_pointcloud` being broken and needing a component rewrite, I have intentionally excluded it from this PR to avoid pointing users to a broken package).*

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed 
- [ ] All tests passed 
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review another open pull request