### PR TITLE
ci: clarify macos dependency details

### DIFF
--- a/ci.md
+++ b/ci.md
@@ -53,7 +53,7 @@ Here's a summary of all checks.
 Platform | Job name | OS | What does it do? | Where dependencies come from?
 --- | --- | --- | --- | ---
 Jenkins | `<library>-ci-pr_any-ubuntu-auto-amd64` | Ubuntu | Compile and run tests using CMake and Make | Stable binaries for stable branches, nightlies for `main`
-Jenkins | `<library>-ci-pr_any-homebrew-amd64` | macOS | Compile and run tests using CMake and Make | Homebrew binaries bottled from `osrf/simulation` tap
+Jenkins | `<library>-ci-pr_any-homebrew-amd64` | macOS | Compile and run tests using CMake and Make | Homebrew formulae from `osrf/simulation` tap (binary bottle of latest stable tag or HEAD from source)
 Jenkins | `<library>-pr-c*win` | Windows | Compile and run tests using [colcon](https://colcon.readthedocs.io/en/released/#) | External dependencies from [conda-forge](https://conda-forge.org/), Gazebo dependencies built from source with colcon
 Jenkins | `<library>-abichecker-any_to_any-ubuntu_auto-amd64` | Ubuntu | Run ABI checker | Stable binaries
 Actions | `Ubuntu CI / Ubuntu * CI` | Ubuntu Bionic and Focal | Compile and run tests using CMake and Make, run code checker and upload coverage results | Stable binaries for stable branches, nightlies for `main`


### PR DESCRIPTION
Noticed while reviewing #665: on macOS, dependency versions are chosen as the latest stable tag for released packages and the tip of the main branch for unreleased packages. Targeting #665 to avoid conflicts.