### PR TITLE
Fix typo "matix" -> "matrix"

### DIFF
--- a/jetty/building_robot.md
+++ b/jetty/building_robot.md
@@ -119,7 +119,7 @@ We define the first link, the `chassis` of our car and it's pose relative to the
 #### Inertial properties
 
 ```xml
-    <inertial> <!--inertial properties of the link mass, inertia matix-->
+    <inertial> <!--inertial properties of the link mass, inertia matrix-->
         <mass>1.14395</mass>
         <inertia>
             <ixx>0.095329</ixx>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a small, unreported typo

## Summary
This PR changes a typo, rewriting the word "matix" to "matrix."

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.