### PR TITLE
Add brew trust osrf/simulation in install docs

### DIFF
--- a/acropolis/install.md
+++ b/acropolis/install.md
@@ -64,6 +64,7 @@ After installing the homebrew package manager, Gazebo Acropolis can be installed
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gazebo-acropolis
 ```
 

--- a/blueprint/install.md
+++ b/blueprint/install.md
@@ -65,6 +65,7 @@ After installing the homebrew package manager, Ignition Blueprint can be install
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install ignition-blueprint
 ```
 

--- a/citadel/install_osx.md
+++ b/citadel/install_osx.md
@@ -11,6 +11,7 @@ After installing the homebrew package manager, Ignition Citadel can be installed
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install ignition-citadel
 ```
 

--- a/citadel/install_osx_src.md
+++ b/citadel/install_osx_src.md
@@ -75,6 +75,7 @@ Add `osrf/simulation` to Homebrew formulae
 ```bash
 brew update
 brew tap osrf/simulation
+brew trust osrf/simulation
 ```
 
 Install all dependencies:

--- a/dome/install_osx.md
+++ b/dome/install_osx.md
@@ -13,6 +13,7 @@ After installing the homebrew package manager, Ignition Dome can be installed ru
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install ignition-dome
 ```
 

--- a/dome/install_osx_src.md
+++ b/dome/install_osx_src.md
@@ -75,6 +75,7 @@ Add `osrf/simulation` to Homebrew formulae
 ```bash
 brew update
 brew tap osrf/simulation
+brew trust osrf/simulation
 ```
 
 Install all dependencies:

--- a/edifice/install_osx.md
+++ b/edifice/install_osx.md
@@ -13,6 +13,7 @@ After installing the homebrew package manager, Ignition Edifice can be installed
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install ignition-edifice
 ```
 

--- a/edifice/install_osx_src.md
+++ b/edifice/install_osx_src.md
@@ -75,6 +75,7 @@ Add `osrf/simulation` to Homebrew formulae
 ```bash
 brew update
 brew tap osrf/simulation
+brew trust osrf/simulation
 ```
 
 Install all dependencies:

--- a/fortress/install_osx.md
+++ b/fortress/install_osx.md
@@ -13,6 +13,7 @@ After installing the homebrew package manager, Ignition Fortress can be installe
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install ignition-fortress
 ```
 

--- a/fortress/install_osx_src.md
+++ b/fortress/install_osx_src.md
@@ -75,6 +75,7 @@ Add `osrf/simulation` to Homebrew formulae
 ```bash
 brew update
 brew tap osrf/simulation
+brew trust osrf/simulation
 ```
 
 Install all dependencies:

--- a/garden/install_osx.md
+++ b/garden/install_osx.md
@@ -13,6 +13,7 @@ After installing the homebrew package manager, Gazebo Gadrden can be installed r
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gz-garden
 ```
 

--- a/garden/install_osx_src.md
+++ b/garden/install_osx_src.md
@@ -76,6 +76,7 @@ Add `osrf/simulation` to Homebrew formulae
 ```bash
 brew update
 brew tap osrf/simulation
+brew trust osrf/simulation
 ```
 
 Install all dependencies:

--- a/harmonic/install_osx.md
+++ b/harmonic/install_osx.md
@@ -5,6 +5,7 @@ All the Harmonic binaries are available in Big Sur and Monterey using the
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gz-harmonic
 ```
 

--- a/harmonic/install_osx_src.md
+++ b/harmonic/install_osx_src.md
@@ -17,6 +17,7 @@ Tools and dependencies for Harmonic can be installed using the [Homebrew package
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew update
 ```
 

--- a/ionic/install_osx.md
+++ b/ionic/install_osx.md
@@ -6,6 +6,7 @@ All the Ionic binaries are available in Monterey and Ventura using the
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gz-ionic
 ```
 

--- a/ionic/install_osx_src.md
+++ b/ionic/install_osx_src.md
@@ -17,6 +17,7 @@ Tools and dependencies for Ionic can be installed using the [Homebrew package ma
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew update
 ```
 

--- a/jetty/install_osx.md
+++ b/jetty/install_osx.md
@@ -6,6 +6,7 @@ All the Jetty binaries are available in Ventura and Sonoma using the
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gz-jetty
 ```
 

--- a/jetty/install_osx_src.md
+++ b/jetty/install_osx_src.md
@@ -17,6 +17,7 @@ Tools and dependencies for Jetty can be installed using the [Homebrew package ma
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew update
 ```
 


### PR DESCRIPTION
# 🦟 Bug fix

Similar to https://github.com/gazebo-tooling/release-tools/pull/1508

## Summary

Homebrew's package descriptions (formulae) are implemented as executable ruby code, which can lead to security issues when using 3rd-party taps, so they have recently added a `brew trust` command to help mitigate security issues, [documented here](https://docs.brew.sh/Tap-Trust). It will soon be required to use `brew trust osrf/simulation` after `brew tap osrf/simulation` in order to run additional commands like `brew install gz-jetty`. I have added these commands to our CI scripts to fix `brew doctor` complaints in CI in https://github.com/gazebo-tooling/release-tools/pull/1508 and have opened this PR to update our documentation, adding `brew trust osrf/simulation` after every instance of `brew tap osrf/simulation` that I could find.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
