### PR TITLE
rotary: brew trust osrf/simulation

### DIFF
--- a/rotary/install_osx_src.md
+++ b/rotary/install_osx_src.md
@@ -17,6 +17,7 @@ Tools and dependencies for Rotary can be installed using the [Homebrew package m
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew update
 ```
 

--- a/rotary/rotary.md
+++ b/rotary/rotary.md
@@ -99,6 +99,7 @@ Rotary formulae are published through the
 
 ```bash
 brew tap osrf/simulation
+brew trust osrf/simulation
 brew install gz-rotary
 ```
 


### PR DESCRIPTION
Apply `brew trust osrf/simulation` changes from https://github.com/gazebosim/docs/pull/692 to Rotary, whose documentation was added in https://github.com/gazebosim/docs/pull/685 without this change.