### PR TITLE
Extend Ionic, Harmonic, Fortress support windows to match ROS

### DIFF
--- a/common/get_started.md
+++ b/common/get_started.md
@@ -43,9 +43,9 @@ there is an installation package per release available with all the
 installation options:
 
 * [Gazebo Jetty installation](/docs/jetty/install){.external} options (Expected: EOL 2031 May)
-* [Gazebo Ionic installation](/docs/ionic/install){.external} options (EOL 2026 Sep)
-* [Gazebo Harmonic (LTS) installation](/docs/harmonic/install){.external} options (EOL 2028 Sep)
-* [Gazebo Fortress (LTS) installation](/docs/fortress/install){.external} options (EOL 2026 Sep)
+* [Gazebo Ionic installation](/docs/ionic/install){.external} options (EOL 2026 Dec)
+* [Gazebo Harmonic (LTS) installation](/docs/harmonic/install){.external} options (EOL 2029 May)
+* [Gazebo Fortress (LTS) installation](/docs/fortress/install){.external} options (EOL 2027 May)
 
 If you want to test the latest, unreleased Gazebo changes from `main`, see
 the [Rotary release](/docs/rotary/rotary){.external} documentation. Rotary is a

--- a/common/releases.md
+++ b/common/releases.md
@@ -27,10 +27,10 @@ installation instructions.
 | [Rotary](https://gazebosim.org/docs/rotary)              | Rolling   | —         | Experimental |
 | M                                                        | Mar, 2027 | Dec, 2028 |       |
 | [Jetty](https://gazebosim.org/docs/jetty)                | Sep, 2025 | May, 2031 | Long-term support (LTS) |
-| [Ionic](https://gazebosim.org/docs/ionic)                | Sep, 2024 | Sep, 2026 |       |
-| [Harmonic](https://gazebosim.org/docs/harmonic)          | Sep, 2023 | Sep, 2028 | Long-term support (LTS) |
+| [Ionic](https://gazebosim.org/docs/ionic)                | Sep, 2024 | Dec, 2026 |       |
+| [Harmonic](https://gazebosim.org/docs/harmonic)          | Sep, 2023 | May, 2029 | Long-term support (LTS) |
 | [Garden](https://gazebosim.org/docs/garden)              | Sep, 2022 | Nov, 2024 | End of life (EOL)       |
-| [Fortress](https://gazebosim.org/docs/fortress)          | Sep, 2021 | Sep, 2026 | Long-term support (LTS) |
+| [Fortress](https://gazebosim.org/docs/fortress)          | Sep, 2021 | May, 2027 | Long-term support (LTS) |
 | [Edifice](https://gazebosim.org/docs/edifice)            | Mar, 2021 | Mar, 2022 | End of life (EOL)       |
 | [Dome](https://gazebosim.org/docs/dome)                  | Sep, 2020 | Dec, 2021 | End of life (EOL)       |
 | [Citadel](https://gazebosim.org/docs/citadel)            | Dec, 2019 | Dec, 2024 | End of life (EOL)       |
@@ -45,10 +45,10 @@ gantt
                           
     M                  :gz_m,      2027-03, 2028-12
     Jetty       :crit, :jetty,     2025-09, 2031-05
-    Ionic       :crit, :ionic,     2024-09, 2y
-    Harmonic    :crit, :harmonic,  2023-09, 5y
+    Ionic       :crit, :ionic,     2024-09, 2026-12
+    Harmonic    :crit, :harmonic,  2023-09, 2029-05
     Garden             :garden,    2022-09, 2024-11
-    Fortress    :crit, :fortress,  2021-09, 5y
+    Fortress    :crit, :fortress,  2021-09, 2027-05
     Edifice            :edifice,   2021-03, 1y
     Dome               :dome,      2020-09, 2021-12
     Citadel            :citadel,   2019-12, 5y

--- a/index.yaml
+++ b/index.yaml
@@ -102,7 +102,7 @@ releases:
     lts: false
     eol: false
     preferred: false # Only one preferred=true is allowed
-    description: Supported Sep, 2024 to Sep, 2026
+    description: Supported Sep, 2024 to Dec, 2026
     libraries:
       - name: cmake
         version: 4
@@ -139,7 +139,7 @@ releases:
   - name: harmonic
     lts: true
     eol: false
-    description: Supported Sep, 2023 to Sep, 2028
+    description: Supported Sep, 2023 to May, 2029
     libraries:
       - name: cmake
         version: 3
@@ -213,7 +213,7 @@ releases:
   - name: fortress
     lts: true
     eol: false
-    description: Supported Sep, 2021 to Sep, 2026
+    description: Supported Sep, 2021 to May, 2027
     libraries:
       - name: cmake
         version: 2

--- a/tools/versions.md
+++ b/tools/versions.md
@@ -23,7 +23,7 @@ How to read the columns:
 |---|---|---|---|---|---|---|---|---|---|
 |gz-cmake|0| EOL ❌ |B C D E F|X Z A B||||2017-10-09|2023-01-25 with Gazebo 9|
 ||1|EOL ❌||X B||||2018-12-12|-|
-||2|stable|F|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
+||2|stable|F|B F J|F J|11|A B C D E F|2019-01-31|2027-05 with Fortress|
 ||3|stable||F J N|||G H|2022-09-23|2029-05 with Harmonic|
 ||4|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||5|stable|||||J|2025-09-01|2031-05 with Jetty|
@@ -31,7 +31,7 @@ How to read the columns:
 ||1|EOL ❌|B C D E F|X Z A B||9 10||2018-01-05|2023-01-25 with Gazebo 9|
 ||2|EOL ❌||X B||||2019-02-11|-|
 ||3|EOL ❌|G H I J K L|B F|F|11|A B C D|2019-02-28|2025-01-25 with Gazebo 11|
-||4|stable|J K L|B F J|F J| |E F|2020-03-31|2026-09 with Fortress|
+||4|stable|J K L|B F J|F J| |E F|2020-03-31|2027-05 with Fortress|
 ||5|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||6|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||7|stable|||||J|2025-09-01|2031-05 with Jetty|
@@ -42,7 +42,7 @@ How to read the columns:
 ||4|EOL ❌|G H I J K L|B F|F|11|C|2019-12-10|2025-01-25 with Gazebo 11|
 ||5|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||6|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||7|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||7|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||8|EOL ❌||F J|||G|2022-09-26|2024-11 with Garden|
 ||9|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||10|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -52,7 +52,7 @@ How to read the columns:
 ||3|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||4|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||6|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -63,7 +63,7 @@ How to read the columns:
 ||3|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||4|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||6|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -73,7 +73,7 @@ How to read the columns:
 ||2|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||3|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||4|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||5|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||7|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -84,7 +84,7 @@ How to read the columns:
 ||3|EOL ❌||T X Y Z A||8||2017-01-05|2019-01-25 with gazebo8|
 ||4|EOL ❌|B C D E F|X Z A B||9 10||2017-12-26|2023-01-25 with Gazebo 9|
 ||5|EOL ❌||X B||||2018-12-12||
-||6|stable|G H I J K L|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
+||6|stable|G H I J K L|B F J|F J|11|A B C D E F|2019-01-31|2027-05 with Fortress|
 ||7|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
@@ -96,7 +96,7 @@ How to read the columns:
 ||5|EOL ❌|G H I J K L|B F|F|11|C|2019-12-10|2025-01-25 with Gazebo 11|
 ||6|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||7|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||8|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||8|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||9|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||10|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||11|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -105,12 +105,12 @@ How to read the columns:
 ||2|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||3|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||4|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||5|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-21|2024-11 with Garden|
 ||7|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
-|gz-plugin|1|stable|J K L|B F J|F J||A B C D E F|2019-03-01|2026-09 with Fortress|
+|gz-plugin|1|stable|J K L|B F J|F J||A B C D E F|2019-03-01|2027-05 with Fortress|
 ||2|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
@@ -119,7 +119,7 @@ How to read the columns:
 ||3|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||4|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||6|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
@@ -129,13 +129,13 @@ How to read the columns:
 ||3|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
 ||4|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||6|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-tools|0|EOL ❌||X A B|||A B|2018-02-22|2020-12 with Blueprint|
-||1|stable|J K L|B F J|F J|11|C D E F|2019-05-21|2026-09 with Fortress|
+||1|stable|J K L|B F J|F J|11|C D E F|2019-05-21|2027-05 with Fortress|
 ||2|stable||F J N|||G H I J|2022-09-22|2031-05 with Jetty|
 |gz-transport|0|EOL ❌|X|P T V W||||2014-08-12||
 ||1|EOL ❌||T V W X||||2016-02-05||
@@ -148,12 +148,12 @@ How to read the columns:
 ||8|EOL ❌|J K L|B F|F|11|C|2019-12-10|2025-01-25 with Gazebo 11|
 ||9|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||10|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||11|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||11|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||12|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||13|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||14|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||15|stable|||||J|2025-09-01|2031-05 with Jetty|
-|gz-utils|1|stable|J K L|B F J|F J||E F|2020-03-31|2026-09 with Fortress|
+|gz-utils|1|stable|J K L|B F J|F J||E F|2020-03-31|2027-05 with Fortress|
 ||2|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
@@ -168,7 +168,7 @@ How to read the columns:
 ||9|EOL ❌|J K L|B F|F|11|C|2019-12-10|2025-01-25 with Gazebo 11|
 ||10|EOL ❌|||||D|2020-09-30|2021-12 with Dome|
 ||11|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
-||12|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
+||12|stable|J K L|B F J|F J||F|2021-09-30|2027-05 with Fortress|
 ||13|EOL ❌||F J|||G|2022-09-23|2024-11 with Garden|
 ||14|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||15|stable||N|||I|2024-09-26|2026-12 with Ionic|

--- a/tools/versions.md
+++ b/tools/versions.md
@@ -25,7 +25,7 @@ How to read the columns:
 ||1|EOL ❌||X B||||2018-12-12|-|
 ||2|stable|F|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
 ||3|stable||F J N|||G H|2022-09-23|2028-09 with Harmonic|
-||4|stable||N|||H I|2024-09-26|2026-09 with Ionic|
+||4|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||5|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-common|0|EOL ❌||T X Y Z A||||2016-07-27|-|
 ||1|EOL ❌|B C D E F|X Z A B||9 10||2018-01-05|2023-01-25 with Gazebo 9|
@@ -33,7 +33,7 @@ How to read the columns:
 ||3|EOL ❌|G H I J K L|B F|F|11|A B C D|2019-02-28|2025-01-25 with Gazebo 11|
 ||4|stable|J K L|B F J|F J| |E F|2020-03-31|2026-09 with Fortress|
 ||5|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
-||6|stable||N|||H I|2024-09-26|2026-09 with Ionic|
+||6|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||7|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-fuel-tools|0|EOL ❌||X Z A||||2017|-|
 ||1|EOL ❌|B C D E F|X A B||9 10||2018-01-25|2023-01-25 with Gazebo 9|
@@ -45,7 +45,7 @@ How to read the columns:
 ||7|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||8|EOL ❌||F J|||G|2022-09-26|2024-11 with Garden|
 ||9|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||10|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||10|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||11|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-sim|1|EOL ❌||B|||A|2019-03-02|2019-09 with Acropolis|
 ||2|EOL ❌||B|||B|2019-05-21|2020-12 with Blueprint|
@@ -55,7 +55,7 @@ How to read the columns:
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||9|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-gui|0|EOL ❌||B||||2019-03-06|-|
 ||1|EOL ❌||B|||A|2019-03-01|2019-09 with Acropolis|
@@ -66,7 +66,7 @@ How to read the columns:
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||9|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-launch|0|EOL ❌||B|||A|2019-03-18|2019-09 with Acropolis|
 ||1|EOL ❌||B|||B|2019-05-21|2020-12 with Blueprint|
@@ -76,7 +76,7 @@ How to read the columns:
 ||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
 ||7|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||8|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-math|0|EOL ❌||P T||||2014-06-16|-|
 ||1|EOL ❌||||||2015-03-06|-|
@@ -86,7 +86,7 @@ How to read the columns:
 ||5|EOL ❌||X B||||2018-12-12||
 ||6|stable|G H I J K L|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
 ||7|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
-||8|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-msgs|0|EOL ❌||P T X Z A B||8||2014-07-14|2019-01-25 with gazebo8|
 ||1|EOL ❌|B C D E F|T W X Y Z A||9 10||2017-10-04|2023-01-25 with Gazebo 9|
@@ -99,7 +99,7 @@ How to read the columns:
 ||8|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||9|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||10|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||11|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||11|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||12|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-physics|1|EOL ❌||B|||A B|2019-03-01|2020-12 with Blueprint|
 ||2|EOL ❌||B F|F||C|2019-12-10|2024-12 with Citadel|
@@ -108,11 +108,11 @@ How to read the columns:
 ||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-21|2024-11 with Garden|
 ||7|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||8|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-plugin|1|stable|J K L|B F J|F J||A B C D E F|2019-03-01|2026-09 with Fortress|
 ||2|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
-||3|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-rendering|1|EOL ❌||B|||A|2019-02-28|2019-09 with Acropolis|
 ||2|EOL ❌||B|||B|2019-05-20|2020-12 with Blueprint|
@@ -122,7 +122,7 @@ How to read the columns:
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||9|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-sensors|1|EOL ❌||B|||A|2019-03-01|2019-09 with Acropolis|
 ||2|EOL ❌||B|||B|2019-05-21|2020-12 with Blueprint|
@@ -132,7 +132,7 @@ How to read the columns:
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||9|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-tools|0|EOL ❌||X A B|||A B|2018-02-22|2020-12 with Blueprint|
 ||1|stable|J K L|B F J|F J|11|C D E F|2019-05-21|2026-09 with Fortress|
@@ -151,11 +151,11 @@ How to read the columns:
 ||11|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||12|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
 ||13|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||14|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||14|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||15|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-utils|1|stable|J K L|B F J|F J||E F|2020-03-31|2026-09 with Fortress|
 ||2|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
-||3|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
 |SDFormat|1|EOL ❌||P W||2||2013-03-28|2016-01-25 with gazebo2|
 ||2|EOL ❌||P T V||3 4 5||2014-04-11|2017-01-25 with gazebo5|
@@ -171,7 +171,7 @@ How to read the columns:
 ||12|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||13|EOL ❌||F J|||G|2022-09-23|2024-11 with Garden|
 ||14|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
-||15|stable||N|||I|2024-09-26|2026-09 with Ionic|
+||15|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||16|stable|||||J|2025-09-01|2031-05 with Jetty|
 |Gazebo classic|1|EOL ❌||P||||2012-12-09|2015-07-27|
 ||2|EOL ❌||T||||2013-10-08|2016-01-25|

--- a/tools/versions.md
+++ b/tools/versions.md
@@ -24,7 +24,7 @@ How to read the columns:
 |gz-cmake|0| EOL ❌ |B C D E F|X Z A B||||2017-10-09|2023-01-25 with Gazebo 9|
 ||1|EOL ❌||X B||||2018-12-12|-|
 ||2|stable|F|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
-||3|stable||F J N|||G H|2022-09-23|2028-09 with Harmonic|
+||3|stable||F J N|||G H|2022-09-23|2029-05 with Harmonic|
 ||4|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||5|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-common|0|EOL ❌||T X Y Z A||||2016-07-27|-|
@@ -32,7 +32,7 @@ How to read the columns:
 ||2|EOL ❌||X B||||2019-02-11|-|
 ||3|EOL ❌|G H I J K L|B F|F|11|A B C D|2019-02-28|2025-01-25 with Gazebo 11|
 ||4|stable|J K L|B F J|F J| |E F|2020-03-31|2026-09 with Fortress|
-||5|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
+||5|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||6|stable||N|||H I|2024-09-26|2026-12 with Ionic|
 ||7|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-fuel-tools|0|EOL ❌||X Z A||||2017|-|
@@ -44,7 +44,7 @@ How to read the columns:
 ||6|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||7|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||8|EOL ❌||F J|||G|2022-09-26|2024-11 with Garden|
-||9|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||9|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||10|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||11|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-sim|1|EOL ❌||B|||A|2019-03-02|2019-09 with Acropolis|
@@ -54,7 +54,7 @@ How to read the columns:
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
-||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-gui|0|EOL ❌||B||||2019-03-06|-|
@@ -65,7 +65,7 @@ How to read the columns:
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
-||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-launch|0|EOL ❌||B|||A|2019-03-18|2019-09 with Acropolis|
@@ -75,7 +75,7 @@ How to read the columns:
 ||4|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-27|2024-11 with Garden|
-||7|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||7|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-math|0|EOL ❌||P T||||2014-06-16|-|
@@ -85,7 +85,7 @@ How to read the columns:
 ||4|EOL ❌|B C D E F|X Z A B||9 10||2017-12-26|2023-01-25 with Gazebo 9|
 ||5|EOL ❌||X B||||2018-12-12||
 ||6|stable|G H I J K L|B F J|F J|11|A B C D E F|2019-01-31|2026-09 with Fortress|
-||7|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
+||7|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-msgs|0|EOL ❌||P T X Z A B||8||2014-07-14|2019-01-25 with gazebo8|
@@ -98,7 +98,7 @@ How to read the columns:
 ||7|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||8|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||9|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
-||10|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||10|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||11|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||12|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-physics|1|EOL ❌||B|||A B|2019-03-01|2020-12 with Blueprint|
@@ -107,11 +107,11 @@ How to read the columns:
 ||4|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||5|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||6|EOL ❌||F J|||G|2022-09-21|2024-11 with Garden|
-||7|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||7|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||8|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||9|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-plugin|1|stable|J K L|B F J|F J||A B C D E F|2019-03-01|2026-09 with Fortress|
-||2|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
+||2|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-rendering|1|EOL ❌||B|||A|2019-02-28|2019-09 with Acropolis|
@@ -121,7 +121,7 @@ How to read the columns:
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
-||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-sensors|1|EOL ❌||B|||A|2019-03-01|2019-09 with Acropolis|
@@ -131,7 +131,7 @@ How to read the columns:
 ||5|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||6|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||7|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
-||8|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||8|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||9|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||10|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-tools|0|EOL ❌||X A B|||A B|2018-02-22|2020-12 with Blueprint|
@@ -150,11 +150,11 @@ How to read the columns:
 ||10|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||11|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||12|EOL ❌||F J|||G|2022-09-22|2024-11 with Garden|
-||13|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||13|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||14|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||15|stable|||||J|2025-09-01|2031-05 with Jetty|
 |gz-utils|1|stable|J K L|B F J|F J||E F|2020-03-31|2026-09 with Fortress|
-||2|stable||F J N|||G H|2022-09-22|2028-09 with Harmonic|
+||2|stable||F J N|||G H|2022-09-22|2029-05 with Harmonic|
 ||3|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||4|stable|||||J|2025-09-01|2031-05 with Jetty|
 |SDFormat|1|EOL ❌||P W||2||2013-03-28|2016-01-25 with gazebo2|
@@ -170,7 +170,7 @@ How to read the columns:
 ||11|EOL ❌|||F||E|2020-03-31|2022-03 with Edifice|
 ||12|stable|J K L|B F J|F J||F|2021-09-30|2026-09 with Fortress|
 ||13|EOL ❌||F J|||G|2022-09-23|2024-11 with Garden|
-||14|stable||J N|||H|2023-09-29|2028-09 with Harmonic|
+||14|stable||J N|||H|2023-09-29|2029-05 with Harmonic|
 ||15|stable||N|||I|2024-09-26|2026-12 with Ionic|
 ||16|stable|||||J|2025-09-01|2031-05 with Jetty|
 |Gazebo classic|1|EOL ❌||P||||2012-12-09|2015-07-27|


### PR DESCRIPTION
Follow-up to https://github.com/gazebosim/docs/pull/670.

Update end-of-life dates for several Gazebo collections to match the corresponding ROS distribution end-of-life date:

* Extend Gazebo Ionic EOL from Sep-2026 to Dec-2026 to match ROS Kilted
* Extend Gazebo Harmonic EOL from Sep-2028 to May-2029 to match ROS Kilted
* Extend Gazebo Fortress EOL from Sep-2026 to May-2027 to match ROS Kilted

