### PR TITLE
Correct SpawnEntity service call example

### DIFF
--- a/jetty/ros2_sim_interfaces.md
+++ b/jetty/ros2_sim_interfaces.md
@@ -103,7 +103,9 @@ Spawn a new entity in the simulation at a specific location.
 ```bash
 ros2 service call /gzserver/spawn_entity simulation_interfaces/srv/SpawnEntity "{
   name: 'my_model',
-  uri: '/path/to/model.sdf',
+  entity_resource: {
+    uri: '/path/to/model.sdf'
+  },
   allow_renaming: false,
   initial_pose: {
     pose: {

--- a/rotary/ros2_sim_interfaces.md
+++ b/rotary/ros2_sim_interfaces.md
@@ -103,7 +103,9 @@ Spawn a new entity in the simulation at a specific location.
 ```bash
 ros2 service call /gzserver/spawn_entity simulation_interfaces/srv/SpawnEntity "{
   name: 'my_model',
-  uri: '/path/to/model.sdf',
+  entity_resource: {
+    uri: '/path/to/model.sdf'
+  },
   allow_renaming: false,
   initial_pose: {
     pose: {


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/ros-simulation/simulation_interfaces/pull/4

## Summary
This PR updates the SpawnEntity service documentation example to match the current `simulation_interfaces/srv/SpawnEntity definition`.

Previously, the example passed the model path through the top-level `uri`:
``` bash
uri: '/path/to/model.sdf'
```
However, `simulation_interfaces/srv/SpawnEntity` was updated to replace the old top-level string `uri` field with Resource `entity_resource`. As a result, the documented command no longer matches the service interface and fails when copied directly.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
