### PR TITLE
Fix fortress CI by switching from Focal to Jammy

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ubuntu_distribution: focal
+          - ubuntu_distribution: jammy
             gazebo_distribution: fortress
 
           - ubuntu_distribution: jammy


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `Deploy API Docs` workflow has been broken for a while https://github.com/gazebosim/docs/actions/runs/29398576409 due to an error in `setup-gazebo` action. The reported error is "incompatible Gazebo and Ubuntu combination". I believe this is because the configured OS for Fortress was changed to Ubuntu Jammy when Ubuntu Focal went EOL in https://github.com/gazebo-tooling/release-tools/pull/1428.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
