### PR TITLE
nightly-upload: stop using jetty prereleases

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -33,7 +33,7 @@ jobs:
         uses: gazebo-tooling/setup-gazebo@v0.3.0
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
-          use-gazebo-prerelease: ${{ matrix.gazebo_distribution == 'jetty'}}
+          # use-gazebo-prerelease: ${{ matrix.gazebo_distribution == 'next'}}
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen graphviz texlive-latex-extra
       - name: 'Add missing dependencies'


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1271.

## Summary

I noticed that the nightly-upload workflow is still using prereleases for jetty, but we should be able to use stable releases now.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [x] Other (fill in yourself): irrelevant

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
